### PR TITLE
refactor: remove premium_user import

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1130,7 +1130,7 @@ Model Info:
         email_logo_url: Optional[str] = None,
         email_support_contact: Optional[str] = None,
     ):
-        from litellm.proxy.proxy_server import CommonProxyErrors, premium_user
+        from litellm.proxy.proxy_server import CommonProxyErrors
 
         if premium_user is not True:
             if email_logo_url is not None or email_support_contact is not None:


### PR DESCRIPTION
## Summary
- rely on function argument for premium email feature check

## Testing
- `ruff check litellm/integrations/SlackAlerting/slack_alerting.py`
- `pytest tests/logging_callback_tests/test_alerting.py::test_alerting_metadata -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a80dfeb40c83219e33c92951e0227d