### PR TITLE
refactor: centralize premium checks

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, Request, status
 from litellm import Router, provider_list
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
+from litellm.proxy.utils import _premium_user_check
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 
 
@@ -195,7 +196,7 @@ async def pre_db_read_auth_checks(
     Raises:
     - HTTPException if request fails initial auth checks
     """
-    from litellm.proxy.proxy_server import general_settings, llm_router, premium_user
+    from litellm.proxy.proxy_server import general_settings, llm_router
 
     # Check 1. request size
     await check_if_request_size_is_safe(request=request)
@@ -225,11 +226,8 @@ async def pre_db_read_auth_checks(
 
     # Check 4. Check if request route is an allowed route on the proxy
     if "allowed_routes" in general_settings:
+        _premium_user_check()
         _allowed_routes = general_settings["allowed_routes"]
-        if premium_user is not True:
-            verbose_proxy_logger.error(
-                f"Trying to set allowed_routes. This is an Enterprise feature. {CommonProxyErrors.not_premium_user.value}"
-            )
         if route not in _allowed_routes:
             verbose_proxy_logger.error(
                 f"Route {route} not in allowed_routes={_allowed_routes}"
@@ -261,13 +259,10 @@ def route_in_additonal_public_routes(current_route: str):
     ```
     """
 
-    # check if user is premium_user - if not do nothing
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.proxy_server import general_settings
 
     try:
-        if premium_user is not True:
-            return False
-        # check if this is defined on the config
+        _premium_user_check()
         if general_settings is None:
             return False
 
@@ -317,18 +312,12 @@ async def check_if_request_size_is_safe(request: Request) -> bool:
         ProxyException: If the request size is too large
 
     """
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.proxy_server import general_settings
 
     max_request_size_mb = general_settings.get("max_request_size_mb", None)
 
     if max_request_size_mb is not None:
-        # Check if premium user
-        if premium_user is not True:
-            verbose_proxy_logger.warning(
-                f"using max_request_size_mb - not checking -  this is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
-            )
-            return True
-
+        _premium_user_check()
         # Get the request body
         content_length = request.headers.get("content-length")
 
@@ -382,17 +371,11 @@ async def check_response_size_is_safe(response: Any) -> bool:
 
     """
 
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.proxy_server import general_settings
 
     max_response_size_mb = general_settings.get("max_response_size_mb", None)
     if max_response_size_mb is not None:
-        # Check if premium user
-        if premium_user is not True:
-            verbose_proxy_logger.warning(
-                f"using max_response_size_mb - not checking -  this is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
-            )
-            return True
-
+        _premium_user_check()
         response_size_mb = bytes_to_mb(bytes_value=sys.getsizeof(response))
         verbose_proxy_logger.debug(f"response size in MB={response_size_mb}")
         if response_size_mb > max_response_size_mb:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -60,6 +60,7 @@ from litellm.proxy.utils import (
     handle_exception_on_proxy,
     is_valid_api_key,
     jsonify_object,
+    _premium_user_check,
 )
 from litellm.router import Router
 from litellm.secret_managers.main import get_secret
@@ -299,7 +300,6 @@ def common_key_access_checks(
     user_api_key_dict: UserAPIKeyAuth,
     data: Union[GenerateKeyRequest, UpdateKeyRequest],
     llm_router: Optional[Router],
-    premium_user: bool,
 ) -> Literal[True]:
     """
     Check if user is allowed to make a key request, for this key
@@ -324,7 +324,6 @@ def common_key_access_checks(
     _check_model_access_group(
         models=data.models,
         llm_router=llm_router,
-        premium_user=premium_user,
     )
     return True
 
@@ -356,7 +355,6 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     from litellm.proxy.proxy_server import (
         litellm_proxy_admin_name,
         llm_router,
-        premium_user,
         prisma_client,
     )
 
@@ -364,7 +362,6 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         user_api_key_dict=user_api_key_dict,
         data=data,
         llm_router=llm_router,
-        premium_user=premium_user,
     )
 
     if (
@@ -497,12 +494,7 @@ async def _common_key_generation_helper(  # noqa: PLR0915
 
     # Set tags on the new key
     if "tags" in data_json:
-        from litellm.proxy.proxy_server import premium_user
-
-        if premium_user is not True and data_json["tags"] is not None:
-            raise ValueError(
-                f"Only premium users can add tags to keys. {CommonProxyErrors.not_premium_user.value}"
-            )
+        _premium_user_check()
 
         _metadata = data_json.get("metadata")
         if not _metadata:
@@ -821,8 +813,6 @@ def prepare_metadata_fields(
                 else:
                     casted_metadata[k] = v
             if k in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
-                from litellm.proxy.utils import _premium_user_check
-
                 _premium_user_check()
                 casted_metadata[k] = v
 
@@ -1031,7 +1021,6 @@ async def update_key_fn(
     """
     from litellm.proxy.proxy_server import (
         llm_router,
-        premium_user,
         prisma_client,
         proxy_logging_obj,
         user_api_key_cache,
@@ -1049,7 +1038,6 @@ async def update_key_fn(
             user_api_key_dict=user_api_key_dict,
             data=data,
             llm_router=llm_router,
-            premium_user=premium_user,
         )
 
         existing_key_row = await prisma_client.get_data(
@@ -1469,7 +1457,7 @@ async def info_key_fn(
 
 
 def _check_model_access_group(
-    models: Optional[List[str]], llm_router: Optional[Router], premium_user: bool
+    models: Optional[List[str]], llm_router: Optional[Router]
 ) -> Literal[True]:
     """
     if is_model_access_group is True + is_wildcard_route is True, check if user is a premium user
@@ -1483,15 +1471,7 @@ def _check_model_access_group(
         if llm_router._is_model_access_group_for_wildcard_route(
             model_access_group=model
         ):
-            if not premium_user:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail={
-                        "error": "Setting a model access group on a wildcard model is only available for LiteLLM Enterprise users.{}".format(
-                            CommonProxyErrors.not_premium_user.value
-                        )
-                    },
-                )
+            _premium_user_check()
 
     return True
 
@@ -1550,7 +1530,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
     ] = None,  # object_permission_id <-> LiteLLM_ObjectPermissionTable
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None,
 ):
-    from litellm.proxy.proxy_server import premium_user, prisma_client
+    from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
         raise Exception(
@@ -1673,13 +1653,8 @@ async def generate_key_helper_fn(  # noqa: PLR0915
         if isinstance(saved_token["metadata"], str):
             saved_token["metadata"] = json.loads(saved_token["metadata"])
         if isinstance(saved_token["permissions"], str):
-            if (
-                "get_spend_routes" in saved_token["permissions"]
-                and premium_user is not True
-            ):
-                raise ValueError(
-                    "get_spend_routes permission is only available for LiteLLM Enterprise users"
-                )
+            if "get_spend_routes" in saved_token["permissions"]:
+                _premium_user_check()
 
             saved_token["permissions"] = json.loads(saved_token["permissions"])
         if isinstance(saved_token["model_max_budget"], str):
@@ -2109,20 +2084,14 @@ async def regenerate_key_fn(
         from litellm.proxy.proxy_server import (
             hash_token,
             master_key,
-            premium_user,
             prisma_client,
             proxy_logging_obj,
             user_api_key_cache,
         )
-
         is_master_key_regeneration = data and data.new_master_key is not None
 
-        if (
-            premium_user is not True and not is_master_key_regeneration
-        ):  # allow master key regeneration for non-premium users
-            raise ValueError(
-                f"Regenerating Virtual Keys is an Enterprise feature, {CommonProxyErrors.not_premium_user.value}"
-            )
+        if not is_master_key_regeneration:
+            _premium_user_check()
 
         # Check if key exists, raise exception if key is not in the DB
         key = data.key if data and data.key else key
@@ -3149,12 +3118,7 @@ def validate_model_max_budget(model_max_budget: Optional[Dict]) -> None:
         if len(model_max_budget) == 0:
             return
         if model_max_budget is not None:
-            from litellm.proxy.proxy_server import CommonProxyErrors, premium_user
-
-            if premium_user is not True:
-                raise ValueError(
-                    f"You must have an enterprise license to set model_max_budget. {CommonProxyErrors.not_premium_user.value}"
-                )
+            _premium_user_check()
             for _model, _budget_info in model_max_budget.items():
                 assert isinstance(_model, str)
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -62,6 +62,7 @@ from litellm.proxy.management_endpoints.types import CustomOpenID
 from litellm.proxy.utils import (
     PrismaClient,
     ProxyLogging,
+    _premium_user_check,
     get_custom_url,
     get_server_root_path,
 )
@@ -84,7 +85,6 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
     Example:
     """
     from litellm.proxy.proxy_server import (
-        premium_user,
         user_custom_ui_sso_sign_in_handler,
     )
 
@@ -105,13 +105,7 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
         or google_client_id is not None
         or generic_client_id is not None
     ):
-        if premium_user is not True:
-            raise ProxyException(
-                message="You must be a LiteLLM Enterprise user to use SSO. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
-                type=ProxyErrorTypes.auth_error,
-                param="premium_user",
-                code=status.HTTP_403_FORBIDDEN,
-            )
+        _premium_user_check()
 
     ####### Detect DB + MASTER KEY in .env #######
     missing_env_vars = show_missing_vars_in_env()
@@ -1750,8 +1744,6 @@ async def debug_sso_login(request: Request):
     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
     Example:
     """
-    from litellm.proxy.proxy_server import premium_user
-
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
     generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
@@ -1762,13 +1754,7 @@ async def debug_sso_login(request: Request):
         or google_client_id is not None
         or generic_client_id is not None
     ):
-        if premium_user is not True:
-            raise ProxyException(
-                message="You must be a LiteLLM Enterprise user to use SSO. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
-                type=ProxyErrorTypes.auth_error,
-                param="premium_user",
-                code=status.HTTP_403_FORBIDDEN,
-            )
+        _premium_user_check()
 
     # get url from request
     redirect_url = SSOAuthenticationHandler.get_redirect_url_for_sso(


### PR DESCRIPTION
## Summary
- centralize premium feature gating with `_premium_user_check`
- use `_premium_user_check` for SSO endpoints
- rely on `_premium_user_check` across key management helpers

## Testing
- `pytest tests/local_testing/test_auth_utils.py::test_configurable_clientside_parameters -q`
- `pytest tests/proxy_unit_tests/test_proxy_routes.py::test_get_request_route_with_base_url -q`


------
https://chatgpt.com/codex/tasks/task_e_68a811b14cec8321b284dc20df79a95d