### PR TITLE
feat: allow overriding premium user via env

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -39,7 +39,11 @@ If `db.useStackgresOperator` is used (not yet implemented):
 | `proxy_config.*`                                           | See [values.yaml](./values.yaml) for default settings.  See [example_config_yaml](../../../litellm/proxy/example_config_yaml/) for configuration examples.                            | N/A  |
 | `extraContainers[]`                                        | An array of additional containers to be deployed as sidecars alongside the LiteLLM Proxy.                                                                                             | `[]`  |
 
-#### Example `environmentSecrets` Secret 
+### Environment Variables
+
+- `LITELLM_PREMIUM_USER`: Override premium license detection. Set to `"True"` to enable enterprise features or `"False"` to disable them. When unset, the proxy will perform its standard license check.
+
+#### Example `environmentSecrets` Secret
 
 ```
 apiVersion: v1

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -452,7 +452,12 @@ except ImportError:
 
 server_root_path = os.getenv("SERVER_ROOT_PATH", "")
 _license_check = LicenseCheck()
-premium_user: bool = _license_check.is_premium()
+_premium_user_env = os.getenv("LITELLM_PREMIUM_USER")
+premium_user: bool = (
+    _premium_user_env.lower() in ["true", "1", "yes"]
+    if _premium_user_env is not None
+    else _license_check.is_premium()
+)
 premium_user_data: Optional["EnterpriseLicenseData"] = (
     _license_check.airgapped_license_data
 )
@@ -554,13 +559,16 @@ async def proxy_startup_event(app: FastAPI):
 
     init_verbose_loggers()
     ## CHECK PREMIUM USER
+    _premium_user_env = os.getenv("LITELLM_PREMIUM_USER")
+    if _premium_user_env is not None:
+        premium_user = _premium_user_env.lower() in ["true", "1", "yes"]
+    else:
+        premium_user = _license_check.is_premium()
     verbose_proxy_logger.debug(
         "litellm.proxy.proxy_server.py::startup() - CHECKING PREMIUM USER - {}".format(
             premium_user
         )
     )
-    if premium_user is False:
-        premium_user = _license_check.is_premium()
 
     ## CHECK MASTER KEY IN ENVIRONMENT ##
     master_key = get_secret_str("LITELLM_MASTER_KEY")


### PR DESCRIPTION
## Summary
- allow explicit premium user configuration using `LITELLM_PREMIUM_USER`
- document `LITELLM_PREMIUM_USER` in deployment README

## Testing
- `pytest tests/proxy_unit_tests/test_audit_logs_proxy.py::test_create_audit_log_for_update_premium_user -q`


------
https://chatgpt.com/codex/tasks/task_e_68a81573f4388321bad625a0efea0fdc