### PR TITLE
Default premium user env var to true

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -41,7 +41,7 @@ If `db.useStackgresOperator` is used (not yet implemented):
 
 ### Environment Variables
 
-- `LITELLM_PREMIUM_USER`: Override premium license detection. Set to `"True"` to enable enterprise features or `"False"` to disable them. When unset, the proxy will perform its standard license check.
+- `LITELLM_PREMIUM_USER`: Override premium license detection. Set to `"True"` to enable enterprise features or `"False"` to disable them. Defaults to `true` when unset.
 
 #### Example `environmentSecrets` Secret
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -248,7 +248,9 @@ from litellm.proxy.management_endpoints.customer_endpoints import (
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     router as internal_user_router,
 )
-from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
+from litellm.proxy.management_endpoints.internal_user_endpoints import (
+    user_update,
+)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,
@@ -295,7 +297,9 @@ from litellm.proxy.middleware.prometheus_auth_middleware import PrometheusAuthMi
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
     router as openai_files_router,
 )
-from litellm.proxy.openai_files_endpoints.files_endpoints import set_files_config
+from litellm.proxy.openai_files_endpoints.files_endpoints import (
+    set_files_config,
+)
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     passthrough_endpoint_router,
 )
@@ -452,12 +456,8 @@ except ImportError:
 
 server_root_path = os.getenv("SERVER_ROOT_PATH", "")
 _license_check = LicenseCheck()
-_premium_user_env = os.getenv("LITELLM_PREMIUM_USER")
-premium_user: bool = (
-    _premium_user_env.lower() in ["true", "1", "yes"]
-    if _premium_user_env is not None
-    else _license_check.is_premium()
-)
+_premium_user_env = os.getenv("LITELLM_PREMIUM_USER", "true")
+premium_user: bool = _premium_user_env.lower() in ["true", "1", "yes"]
 premium_user_data: Optional["EnterpriseLicenseData"] = (
     _license_check.airgapped_license_data
 )
@@ -554,16 +554,13 @@ async def proxy_shutdown_event():
 
 @asynccontextmanager
 async def proxy_startup_event(app: FastAPI):
-    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval
+    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, proxy_batch_polling_interval
     import json
 
     init_verbose_loggers()
     ## CHECK PREMIUM USER
-    _premium_user_env = os.getenv("LITELLM_PREMIUM_USER")
-    if _premium_user_env is not None:
-        premium_user = _premium_user_env.lower() in ["true", "1", "yes"]
-    else:
-        premium_user = _license_check.is_premium()
+    _premium_user_env = os.getenv("LITELLM_PREMIUM_USER", "true")
+    premium_user = _premium_user_env.lower() in ["true", "1", "yes"]
     verbose_proxy_logger.debug(
         "litellm.proxy.proxy_server.py::startup() - CHECKING PREMIUM USER - {}".format(
             premium_user


### PR DESCRIPTION
## Summary
- default `LITELLM_PREMIUM_USER` to "true" and simplify premium user checks
- document that `LITELLM_PREMIUM_USER` defaults to true

## Testing
- `SKIP=check-files-match pre-commit run --files litellm/proxy/proxy_server.py deploy/charts/litellm-helm/README.md`
- `pytest tests/proxy_unit_tests/test_audit_logs_proxy.py::test_create_audit_log_for_update_premium_user -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a817409b808321a84cd572ae7e67de