### PR TITLE
feat: add configurable app name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@ INFINITY_API_KEY = ""
 LITELLM_MASTER_KEY = "sk-1234"
 DATABASE_URL = "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
 STORE_MODEL_IN_DB = "True"
+
+# UI Settings
+UI_APP_NAME = "LiteLLM"
+NEXT_PUBLIC_APP_NAME = "LiteLLM"

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -598,6 +598,7 @@ router_settings:
 | MICROSOFT_CLIENT_SECRET | Client secret for Microsoft services
 | MICROSOFT_TENANT | Tenant ID for Microsoft Azure
 | MICROSOFT_SERVICE_PRINCIPAL_ID | Service Principal ID for Microsoft Enterprise Application. (This is an advanced feature if you want litellm to auto-assign members to Litellm Teams based on their Microsoft Entra ID Groups)
+| NEXT_PUBLIC_APP_NAME | Name displayed in Admin UI; build-time override for app branding
 | NO_DOCS | Flag to disable Swagger UI documentation
 | NO_REDOC | Flag to disable Redoc documentation
 | NO_PROXY | List of addresses to bypass proxy
@@ -701,6 +702,7 @@ router_settings:
 | TOGETHER_AI_EMBEDDING_150_M | Size parameter for Together AI 150M embedding model. Default is 150
 | TOGETHER_AI_EMBEDDING_350_M | Size parameter for Together AI 350M embedding model. Default is 350
 | TOOL_CHOICE_OBJECT_TOKEN_COUNT | Token count for tool choice objects. Default is 4
+| UI_APP_NAME | Server-provided application name for the UI; used if NEXT_PUBLIC_APP_NAME is not set
 | UI_LOGO_PATH | Path to the logo image used in the UI
 | UI_PASSWORD | Password for accessing the UI
 | UI_USERNAME | Username for accessing the UI

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7929,6 +7929,13 @@ async def claim_onboarding_link(data: InvitationClaim):
     return user_obj
 
 
+@app.get("/get_app_name", include_in_schema=False)
+def get_app_name():
+    """Get the current UI app name from environment"""
+    app_name = os.getenv("UI_APP_NAME", "")
+    return {"app_name": app_name}
+
+
 @app.get("/get_logo_url", include_in_schema=False)
 def get_logo_url():
     """Get the current logo URL from environment"""

--- a/ui/litellm-dashboard/src/app/layout.tsx
+++ b/ui/litellm-dashboard/src/app/layout.tsx
@@ -3,10 +3,11 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
+const appName = process.env.NEXT_PUBLIC_APP_NAME || "LiteLLM";
 
 export const metadata: Metadata = {
-  title: "LiteLLM Dashboard",
-  description: "LiteLLM Proxy Admin UI",
+  title: `${appName} Dashboard`,
+  description: `${appName} Proxy Admin UI`,
   icons: { icon: "./favicon.ico" },
 };
 

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -40,6 +40,8 @@ import UIThemeSettings from "@/components/ui_theme_settings"
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner"
 import { cx } from "@/lib/cva.config"
 
+const envAppName = process.env.NEXT_PUBLIC_APP_NAME
+
 function getCookie(name: string) {
   const cookieValue = document.cookie.split("; ").find((row) => row.startsWith(name + "="))
   return cookieValue ? cookieValue.split("=")[1] : null
@@ -81,10 +83,10 @@ interface ProxySettings {
 
 const queryClient = new QueryClient()
 
-function LoadingScreen() {
+function LoadingScreen({ appName }: { appName: string }) {
   return (
     <div className={cx("h-screen", "flex items-center justify-center gap-4")}>
-      <div className="text-lg font-medium py-2 pr-4 border-r border-r-gray-200">🚅 LiteLLM</div>
+      <div className="text-lg font-medium py-2 pr-4 border-r border-r-gray-200">🚅 {appName}</div>
 
       <div className="flex items-center justify-center gap-2">
         <UiLoadingSpinner className="size-4" />
@@ -115,6 +117,7 @@ export default function CreateKeyPage() {
   const [createClicked, setCreateClicked] = useState<boolean>(false)
   const [authLoading, setAuthLoading] = useState(true)
   const [userID, setUserID] = useState<string | null>(null)
+  const [appName, setAppName] = useState<string>(envAppName || "LiteLLM")
 
   const invitation_id = searchParams.get("invitation_id")
 
@@ -149,6 +152,17 @@ export default function CreateKeyPage() {
       // get the information for constructing the proxy base url, and then set the token and auth loading
       setToken(token)
       setAuthLoading(false)
+      if (!envAppName) {
+        const url = proxyBaseUrl ? `${proxyBaseUrl}/get_app_name` : `/get_app_name`
+        fetch(url)
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.app_name) {
+              setAppName(data.app_name)
+            }
+          })
+          .catch((error) => console.warn("Failed to load app name:", error))
+      }
     })
   }, [])
 
@@ -214,11 +228,11 @@ export default function CreateKeyPage() {
   }, [accessToken, userID, userRole])
 
   if (authLoading || redirectToLogin) {
-    return <LoadingScreen />
+    return <LoadingScreen appName={appName} />
   }
 
   return (
-    <Suspense fallback={<LoadingScreen />}>
+    <Suspense fallback={<LoadingScreen appName={appName} />}>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider accessToken={accessToken}>
           {invitation_id ? (


### PR DESCRIPTION
## Summary
- allow customizing dashboard name via `NEXT_PUBLIC_APP_NAME`
- expose backend `UI_APP_NAME` for UI fallback
- document app name env vars

## Testing
- `SKIP=check-files-match pre-commit run --files .env.example docs/my-website/docs/proxy/config_settings.md litellm/proxy/proxy_server.py ui/litellm-dashboard/src/app/layout.tsx ui/litellm-dashboard/src/app/page.tsx`
- `cd ui/litellm-dashboard && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a81a151148832187f21c89bdac7ac0