### PR TITLE
feat: add customizable UI logo path

### DIFF
--- a/docs/my-website/docs/proxy/admin_ui_sso.md
+++ b/docs/my-website/docs/proxy/admin_ui_sso.md
@@ -235,6 +235,8 @@ Example setting a local image (on your container)
 ```shell
 UI_LOGO_PATH="ui_images/logo.jpg"
 ```
+
+To bundle a default logo directly with the UI build, set `NEXT_PUBLIC_LOGO_PATH` to the path of an image placed under `ui/litellm-dashboard/public/` before building the dashboard.
 #### Set Custom Color Theme
 - Navigate to [/enterprise/enterprise_ui](https://github.com/BerriAI/litellm/blob/main/enterprise/enterprise_ui/_enterprise_colors.json)
 - Inside the `enterprise_ui` directory, rename `_enterprise_colors.json` to `enterprise_colors.json`

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -599,6 +599,7 @@ router_settings:
 | MICROSOFT_TENANT | Tenant ID for Microsoft Azure
 | MICROSOFT_SERVICE_PRINCIPAL_ID | Service Principal ID for Microsoft Enterprise Application. (This is an advanced feature if you want litellm to auto-assign members to Litellm Teams based on their Microsoft Entra ID Groups)
 | NEXT_PUBLIC_APP_NAME | Name displayed in Admin UI; build-time override for app branding
+| NEXT_PUBLIC_LOGO_PATH | Path to default UI logo under `ui/litellm-dashboard/public/`; build-time branding override
 | NO_DOCS | Flag to disable Swagger UI documentation
 | NO_REDOC | Flag to disable Redoc documentation
 | NO_PROXY | List of addresses to bypass proxy

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7940,6 +7940,9 @@ def get_app_name():
 def get_logo_url():
     """Get the current logo URL from environment"""
     logo_path = os.getenv("UI_LOGO_PATH", "")
+    if logo_path and not logo_path.startswith(("http://", "https://")):
+        # If the path is local, serve it through /get_image
+        return {"logo_url": "/get_image"}
     return {"logo_url": logo_path}
 
 
@@ -7951,7 +7954,19 @@ def get_image():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     default_logo = os.path.join(current_dir, "logo.jpg")
 
-    logo_path = os.getenv("UI_LOGO_PATH", default_logo)
+    logo_path_setting = os.getenv("UI_LOGO_PATH", "")
+    if not logo_path_setting:
+        logo_path = default_logo
+    elif logo_path_setting.startswith(("http://", "https://")):
+        logo_path = logo_path_setting
+    else:
+        # Treat as path relative to current_dir if not absolute
+        logo_path = (
+            logo_path_setting
+            if os.path.isabs(logo_path_setting)
+            else os.path.join(current_dir, logo_path_setting)
+        )
+
     verbose_proxy_logger.debug("Reading logo from path: %s", logo_path)
 
     # Check if the logo path is an HTTP/HTTPS URL

--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -3,6 +3,10 @@ const nextConfig = {
     output: 'export',
     basePath: '',
     assetPrefix: '/litellm-asset-prefix',  // If a server_root_path is set, this will be overridden by runtime injection
+    env: {
+        // Default logo bundled with the UI; can be overridden at build time
+        NEXT_PUBLIC_LOGO_PATH: '/assets/logos/litellm.jpg',
+    }
 };
 
 nextConfig.experimental = {

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import React, { useState, useEffect } from "react"
 import type { MenuProps } from "antd"
 import { Dropdown, Tooltip } from "antd"
-import { getProxyBaseUrl, Organization } from "@/components/networking"
+import { Organization } from "@/components/networking"
 import { defaultOrg } from "@/components/common_components/default_org"
 import { 
   UserOutlined,
@@ -39,12 +39,8 @@ const Navbar: React.FC<NavbarProps> = ({
   accessToken,
   isPublicPage = false,
 }) => {
-  const baseUrl = getProxyBaseUrl();
   const [logoutUrl, setLogoutUrl] = useState("");
   const { logoUrl } = useTheme();
-  
-  // Simple logo URL: use custom logo if available, otherwise default
-  const imageUrl = logoUrl || `${baseUrl}/get_image`;
 
   useEffect(() => {
     const initializeProxySettings = async () => {
@@ -132,11 +128,13 @@ const Navbar: React.FC<NavbarProps> = ({
           {/* Left side with correct logo positioning */}
           <div className="flex items-center flex-shrink-0">
             <Link href="/" className="flex items-center">
-              <img
-                src={imageUrl}
-                alt="LiteLLM Brand"
-                className="h-8 w-auto"
-              />
+              {logoUrl && (
+                <img
+                  src={logoUrl}
+                  alt="LiteLLM Brand"
+                  className="h-8 w-auto"
+                />
+              )}
             </Link>
           </div>
 

--- a/ui/litellm-dashboard/src/components/ui_theme_settings.tsx
+++ b/ui/litellm-dashboard/src/components/ui_theme_settings.tsx
@@ -159,9 +159,9 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({
               Current Logo
             </Text>
             <div className="bg-gray-50 rounded-lg p-6 flex items-center justify-center min-h-[120px]">
-              {logoUrlInput ? (
-                <img 
-                  src={logoUrlInput} 
+              {(logoUrlInput || logoUrl) ? (
+                <img
+                  src={logoUrlInput || logoUrl!}
                   alt="Custom logo"
                   className="max-w-full max-h-24 object-contain"
                   onError={(e) => {

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -22,7 +22,7 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessToken }) => {
-  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [logoUrl, setLogoUrl] = useState<string | null>(process.env.NEXT_PUBLIC_LOGO_PATH || null);
 
   // Load logo URL from backend on mount
   useEffect(() => {
@@ -38,7 +38,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
               'Content-Type': 'application/json',
             },
           });
-          
+
           if (response.ok) {
             const data = await response.json();
             if (data.values?.logo_url) {
@@ -50,7 +50,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
         }
       }
     };
-    
+
     loadLogoSettings();
   }, [accessToken]);
 


### PR DESCRIPTION
## Summary
- allow UI logo to be bundled via NEXT_PUBLIC_LOGO_PATH
- surface NEXT_PUBLIC_LOGO_PATH to ThemeContext and Navbar
- serve local UI_LOGO_PATH files via /get_logo_url and /get_image

## Testing
- `npm run lint`
- `ruff check litellm/proxy/proxy_server.py`
- `pytest tests/test_litellm/litellm_core_utils/test_token_counter.py` *(fails: MaxRetryError("HTTPSConnectionPool(host='huggingface.co', port=443): Max retries exceeded with url: /Xenova/llama-3-tokenizer/resolve/main/tokenizer.json (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))"), '(Request ID: 46244821-0319-4059-a6c8-ac89ecb1a738)')*


------
https://chatgpt.com/codex/tasks/task_e_68a81d51ca9883219ec7cd3dd8edc084