### PR TITLE
feat: fetch LiteLLM settings from SSM during Docker build

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -65,12 +65,17 @@ RUN dnf -y update && \
 
 # Copy source and prebuilt wheels
 COPY . .
+COPY docker/fetch_litellm_settings.sh docker/
 COPY --from=builder /app/dist/*.whl .
 COPY --from=builder /wheels /wheels
 
 # Install from wheels without contacting PyPI
 RUN pip install --no-cache-dir *.whl /wheels/* --no-index --find-links=/wheels && \
     rm -f *.whl && rm -rf /wheels
+
+# Fetch runtime settings from AWS SSM
+RUN yum install -y awscli && \
+    docker/fetch_litellm_settings.sh
 
 # Generate prisma client and make entrypoints executable
 RUN prisma generate && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,3 +63,27 @@ docker-compose down
 
 -   **`build_admin_ui.sh: not found`**: This error can occur if the Docker build context is not set correctly. Ensure that you are running the `docker-compose` command from the root of the project.
 -   **`Master key is not initialized`**: This error means the `MASTER_key` environment variable is not set. Make sure you have created a `.env` file in the project root with the `MASTER_KEY` defined.
+
+## Fetching LiteLLM settings from AWS SSM
+
+`docker/Dockerfile.local` runs `docker/fetch_litellm_settings.sh` during the image build. The script reads configuration values from AWS Systems Manager Parameter Store and writes them to `/app/litellm_settings.yaml` so the proxy starts with S3 logging enabled.
+
+### Required IAM permissions
+
+The instance or build role must have permission to read the parameters:
+
+```
+ssm:GetParameter
+```
+
+### Parameter naming convention
+
+Parameters are expected at the following paths (replace `<env>` with your environment name):
+
+```
+/parameters/litellm/<env>/S3_BUCKET_NAME
+/parameters/litellm/<env>/S3_REGION_NAME
+/parameters/litellm/<env>/LOG_LEVEL
+```
+
+The script automatically detects the AWS region using the instance metadata service if `S3_REGION_NAME` is not defined.

--- a/docker/fetch_litellm_settings.sh
+++ b/docker/fetch_litellm_settings.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch LiteLLM runtime settings from AWS SSM and write to /app/litellm_settings.yaml
+# Usage: LITELLM_ENV=<env> docker/fetch_litellm_settings.sh
+
+get_parameter_with_retries() {
+  local name="$1"
+  local attempt=1
+  local max_attempts=5
+  local value
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if value=$(aws ssm get-parameter --with-decryption --name "$name" --query 'Parameter.Value' --output text 2>/dev/null); then
+      echo "$value"
+      return 0
+    fi
+    echo "Retrying $name ($attempt/$max_attempts)" >&2
+    attempt=$(( attempt + 1 ))
+    sleep $attempt
+  done
+  echo "Failed to retrieve parameter: $name" >&2
+  return 1
+}
+
+# Determine environment
+LITELLM_ENV="${LITELLM_ENV:-prod}"
+PREFIX="/parameters/litellm/${LITELLM_ENV}"
+
+S3_BUCKET_NAME=$(get_parameter_with_retries "$PREFIX/S3_BUCKET_NAME")
+LOG_LEVEL=$(get_parameter_with_retries "$PREFIX/LOG_LEVEL")
+if S3_REGION_NAME=$(get_parameter_with_retries "$PREFIX/S3_REGION_NAME" 2>/dev/null); then
+  AWS_REGION="$S3_REGION_NAME"
+else
+  AWS_REGION="${AWS_REGION:-}"
+  if [ -z "$AWS_REGION" ]; then
+    TOKEN=$(curl -s -m 5 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true)
+    if [ -n "$TOKEN" ]; then
+      AWS_REGION=$(curl -s -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '(?<=\"region\"\s*:\s*\")([^\"]+)')
+    else
+      AWS_REGION=$(curl -s -m 5 "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '(?<=\"region\"\s*:\s*\")([^\"]+)')
+    fi
+  fi
+fi
+
+cat > /app/litellm_settings.yaml <<EOF2
+litellm_settings:
+  callbacks: ["s3_v2"]
+  s3_callback_params:
+    s3_bucket_name: "$S3_BUCKET_NAME"
+    s3_region_name: "$AWS_REGION"
+  global_log_level: "$LOG_LEVEL"
+EOF2
+


### PR DESCRIPTION
## Summary
- add fetch_litellm_settings.sh to retrieve SSM params and write litellm_settings.yaml
- run script in Dockerfile.local and document required IAM permissions

## Testing
- `bash -n docker/fetch_litellm_settings.sh`
- `shellcheck docker/fetch_litellm_settings.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a855957ce88321983b5ebfc343caec