### PR TITLE
Install AWS CLI v2 from official zip in Dockerfile

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -91,9 +91,11 @@ COPY --from=builder /wheels /wheels
 RUN pip install --no-cache-dir *.whl /wheels/* --no-index --find-links=/wheels && \
     rm -f *.whl && rm -rf /wheels
 
-# Fetch runtime settings from AWS SSM
-RUN yum install -y awscli && \
-    docker/fetch_litellm_settings.sh
+# Install AWS CLI v2 and fetch runtime settings from AWS SSM
+RUN dnf -y install unzip && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip && ./aws/install && rm -rf awscliv2.zip aws/
+RUN docker/fetch_litellm_settings.sh
 
 # Generate prisma client and make entrypoints executable
 RUN prisma generate && \


### PR DESCRIPTION
## Summary
- install AWS CLI v2 from AWS-provided ZIP in Dockerfile.local
- remove failing yum-based AWS CLI installation

## Testing
- `pytest tests/basic_proxy_startup_tests/test_basic_proxy_startup.py::test_health_and_chat_completion -q` *(fails: async def functions are not natively supported)*
- `docker build -f docker/Dockerfile.local -t litellm-local .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68aa14883fe483218fca46223d6a1bd0