### PR TITLE
chore: guard settings fetch when aws cli missing

### DIFF
--- a/docker/fetch_litellm_settings.sh
+++ b/docker/fetch_litellm_settings.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v aws >/dev/null 2>&1; then
+    echo "AWS CLI not installed; skipping settings fetch" >&2
+    exit 0
+fi
+
 # Fetch LiteLLM runtime settings from AWS SSM and write to /app/litellm_settings.yaml
 # Usage: LITELLM_ENV=<env> docker/fetch_litellm_settings.sh
 


### PR DESCRIPTION
## Summary
- skip settings fetch when AWS CLI is not installed

## Testing
- `pre-commit run --files docker/fetch_litellm_settings.sh`
- `bash docker/fetch_litellm_settings.sh`
- `pytest tests/basic_proxy_startup_tests/test_basic_proxy_startup.py` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa16496b648321b9db83c71fccfa8a