### PR TITLE
Determine AWS region for SSM lookups in fetch script

### DIFF
--- a/docker/fetch_litellm_settings.sh
+++ b/docker/fetch_litellm_settings.sh
@@ -21,6 +21,9 @@ fi
 if [ -z "$AWS_REGION" ]; then
   AWS_REGION=$(aws configure get region 2>/dev/null || true)
 fi
+if [ -z "$AWS_REGION" ]; then
+  AWS_REGION="us-east-2"
+fi
 
 get_parameter_with_retries() {
   local name="$1"


### PR DESCRIPTION
## Summary
- Determine AWS_REGION before fetching SSM parameters using EC2 metadata or `aws configure get region`
- Pass `--region` to all `aws ssm get-parameter` calls
- Simplify S3 region logic

## Testing
- `bash -n docker/fetch_litellm_settings.sh`
- `(PATH="/tmp/aws-bin:$PATH" AWS_REGION='' LITELLM_ENV=prod bash docker/fetch_litellm_settings.sh && cat /app/litellm_settings.yaml)`
- `(PATH="/tmp/aws-bin:$PATH" AWS_REGION='' LITELLM_ENV=prod bash -c 'source docker/fetch_litellm_settings.sh >/dev/null; echo "user=$POSTGRESQL_USERID endpt=$POSTGRESQL_ENDPT"')`

------
https://chatgpt.com/codex/tasks/task_e_68aa22d1a36c8321b5d040e7a3f82ee8