### PR TITLE
chore: remove lookbehind from region grep

### DIFF
--- a/docker/fetch_litellm_settings.sh
+++ b/docker/fetch_litellm_settings.sh
@@ -13,9 +13,9 @@ AWS_REGION="${AWS_REGION:-}"
 if [ -z "$AWS_REGION" ]; then
   TOKEN=$(curl -s -m 5 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true)
   if [ -n "$TOKEN" ]; then
-    AWS_REGION=$(curl -s -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '(?<=\"region\"\s*:\s*\")([^\"]+)')
+    AWS_REGION=$(curl -s -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
   else
-    AWS_REGION=$(curl -s -m 5 "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '(?<=\"region\"\s*:\s*\")([^\"]+)')
+    AWS_REGION=$(curl -s -m 5 "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
   fi
 fi
 if [ -z "$AWS_REGION" ]; then


### PR DESCRIPTION
## Summary
- avoid PCRE lookbehind in fetch_litellm_settings.sh's region detection

## Testing
- `pre-commit run --files docker/fetch_litellm_settings.sh`
- `docker build -f docker/Dockerfile.local -t litellm-local-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa26561c708321bf2ff3d5117ee9a5