### PR TITLE
feat: make Docker settings fetch optional

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -95,3 +95,31 @@ Optional parameters to enable S3 logging:
 ```
 
 The script automatically detects the AWS region using the instance metadata service if `S3_REGION_NAME` is not defined. If `S3_BUCKET_NAME` is absent, S3 logging is disabled.
+
+### Skipping the SSM fetch
+
+For local builds or environments without AWS credentials, you can skip the SSM lookup by setting `SKIP_SSM_FETCH=1`:
+
+```bash
+SKIP_SSM_FETCH=1 docker/fetch_litellm_settings.sh
+```
+
+When building the Docker image you may pass it as a build argument:
+
+```bash
+docker build --build-arg SKIP_SSM_FETCH=1 -f docker/Dockerfile.local .
+```
+
+### Overriding settings
+
+`fetch_litellm_settings.sh` falls back to sensible defaults (`LOG_LEVEL=INFO`, PostgreSQL parameters pointing at `localhost`), but you can override any value through environment variables or build arguments. Example:
+
+```bash
+docker build \
+  --build-arg LOG_LEVEL=DEBUG \
+  --build-arg POSTGRESQL_ENDPT=host.docker.internal \
+  --build-arg POSTGRESQL_PASSCODE=mysecret \
+  -f docker/Dockerfile.local .
+```
+
+These arguments are used if the corresponding SSM parameters are missing or if `SKIP_SSM_FETCH` is set.

--- a/docker/fetch_litellm_settings.sh
+++ b/docker/fetch_litellm_settings.sh
@@ -1,29 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Allow skipping the SSM fetch entirely
+if [ "${SKIP_SSM_FETCH:-}" = "1" ]; then
+  echo "SKIP_SSM_FETCH set; skipping settings fetch" >&2
+  exit 0
+fi
+
+FETCH_SETTINGS=true
 if ! command -v aws >/dev/null 2>&1; then
-    echo "AWS CLI not installed; skipping settings fetch" >&2
-    exit 0
+  echo "AWS CLI not installed; skipping settings fetch" >&2
+  FETCH_SETTINGS=false
+elif ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "AWS credentials not configured; skipping settings fetch" >&2
+  FETCH_SETTINGS=false
 fi
 
-# Fetch LiteLLM runtime settings from AWS SSM and write to /app/litellm_settings.yaml
-# Usage: LITELLM_ENV=<env> docker/fetch_litellm_settings.sh
+# If we can't talk to AWS and no overrides are provided, nothing to do
+if ! $FETCH_SETTINGS && [ -z "${LOG_LEVEL:-}${POSTGRESQL_ENDPT:-}${POSTGRESQL_PASSCODE:-}${POSTGRESQL_PORT:-}${POSTGRESQL_USERID:-}${S3_BUCKET_NAME:-}" ]; then
+  exit 0
+fi
 
-AWS_REGION="${AWS_REGION:-}"
-if [ -z "$AWS_REGION" ]; then
-  TOKEN=$(curl -s -m 5 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true)
-  if [ -n "$TOKEN" ]; then
-    AWS_REGION=$(curl -s -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
-  else
-    AWS_REGION=$(curl -s -m 5 "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
-  fi
-fi
-if [ -z "$AWS_REGION" ]; then
-  AWS_REGION=$(aws configure get region 2>/dev/null || true)
-fi
-if [ -z "$AWS_REGION" ]; then
-  AWS_REGION="us-east-2"
-fi
+AWS_REGION="${AWS_REGION:-us-east-2}"
+LOG_LEVEL="${LOG_LEVEL:-}"
+POSTGRESQL_ENDPT="${POSTGRESQL_ENDPT:-}"
+POSTGRESQL_PASSCODE="${POSTGRESQL_PASSCODE:-}"
+POSTGRESQL_PORT="${POSTGRESQL_PORT:-}"
+POSTGRESQL_USERID="${POSTGRESQL_USERID:-}"
+S3_BUCKET_NAME="${S3_BUCKET_NAME:-}"
+S3_REGION_NAME="${S3_REGION_NAME:-}"
 
 get_parameter_with_retries() {
   local name="$1"
@@ -39,29 +44,52 @@ get_parameter_with_retries() {
     attempt=$(( attempt + 1 ))
     sleep $attempt
   done
-  echo "Failed to retrieve parameter: $name" >&2
   return 1
 }
 
-# Determine environment
-LITELLM_ENV="${LITELLM_ENV:-prod}"
-PREFIX="/parameters/litellm/${LITELLM_ENV}"
+if $FETCH_SETTINGS; then
+  # Resolve region
+  TOKEN=$(curl -s -m 5 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true)
+  if [ -n "$TOKEN" ]; then
+    AWS_REGION=$(curl -s -m 5 -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
+  else
+    AWS_REGION=$(curl -s -m 5 "http://169.254.169.254/latest/dynamic/instance-identity/document" | grep -oP '"region"\s*:\s*"\K[^\"]+')
+  fi
+  if [ -z "$AWS_REGION" ]; then
+    AWS_REGION=$(aws configure get region 2>/dev/null || true)
+  fi
+  if [ -z "$AWS_REGION" ]; then
+    AWS_REGION="us-east-2"
+  fi
 
-S3_BUCKET_NAME=$(get_parameter_with_retries "$PREFIX/S3_BUCKET_NAME" 2>/dev/null || true)
-LOG_LEVEL=$(get_parameter_with_retries "$PREFIX/LOG_LEVEL")
-POSTGRESQL_ENDPT=$(get_parameter_with_retries "$PREFIX/POSTGRESQL_ENDPT")
-POSTGRESQL_PASSCODE=$(get_parameter_with_retries "$PREFIX/POSTGRESQL_PASSCODE")
-POSTGRESQL_PORT=$(get_parameter_with_retries "$PREFIX/POSTGRESQL_PORT")
-POSTGRESQL_USERID=$(get_parameter_with_retries "$PREFIX/POSTGRESQL_USERID")
+  LITELLM_ENV="${LITELLM_ENV:-prod}"
+  PREFIX="/parameters/litellm/${LITELLM_ENV}"
+
+  S3_BUCKET_NAME="${S3_BUCKET_NAME:-$(get_parameter_with_retries "$PREFIX/S3_BUCKET_NAME" 2>/dev/null || true)}"
+  LOG_LEVEL="${LOG_LEVEL:-$(get_parameter_with_retries "$PREFIX/LOG_LEVEL" 2>/dev/null || true)}"
+  POSTGRESQL_ENDPT="${POSTGRESQL_ENDPT:-$(get_parameter_with_retries "$PREFIX/POSTGRESQL_ENDPT" 2>/dev/null || true)}"
+  POSTGRESQL_PASSCODE="${POSTGRESQL_PASSCODE:-$(get_parameter_with_retries "$PREFIX/POSTGRESQL_PASSCODE" 2>/dev/null || true)}"
+  POSTGRESQL_PORT="${POSTGRESQL_PORT:-$(get_parameter_with_retries "$PREFIX/POSTGRESQL_PORT" 2>/dev/null || true)}"
+  POSTGRESQL_USERID="${POSTGRESQL_USERID:-$(get_parameter_with_retries "$PREFIX/POSTGRESQL_USERID" 2>/dev/null || true)}"
+
+  if [ -n "$S3_BUCKET_NAME" ]; then
+    S3_REGION_NAME="${S3_REGION_NAME:-$(get_parameter_with_retries "$PREFIX/S3_REGION_NAME" 2>/dev/null || true)}"
+    if [ -n "$S3_REGION_NAME" ]; then
+      AWS_REGION="$S3_REGION_NAME"
+    fi
+  fi
+fi
+
+# Fallback defaults
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+POSTGRESQL_ENDPT="${POSTGRESQL_ENDPT:-localhost}"
+POSTGRESQL_PASSCODE="${POSTGRESQL_PASSCODE:-postgres}"
+POSTGRESQL_PORT="${POSTGRESQL_PORT:-5432}"
+POSTGRESQL_USERID="${POSTGRESQL_USERID:-postgres}"
+S3_REGION_NAME="${S3_REGION_NAME:-$AWS_REGION}"
 
 export POSTGRESQL_ENDPT POSTGRESQL_PASSCODE POSTGRESQL_PORT POSTGRESQL_USERID
 export DATABASE_URL="postgresql://${POSTGRESQL_USERID}:${POSTGRESQL_PASSCODE}@${POSTGRESQL_ENDPT}:${POSTGRESQL_PORT}/postgres"
-
-if [ -n "$S3_BUCKET_NAME" ]; then
-  if S3_REGION_NAME=$(get_parameter_with_retries "$PREFIX/S3_REGION_NAME" 2>/dev/null); then
-    AWS_REGION="$S3_REGION_NAME"
-  fi
-fi
 
 cat > /app/litellm_settings.yaml <<EOF2
 litellm_settings:
@@ -73,7 +101,7 @@ cat >> /app/litellm_settings.yaml <<EOF2
   callbacks: ["s3_v2"]
   s3_callback_params:
     s3_bucket_name: "$S3_BUCKET_NAME"
-    s3_region_name: "$AWS_REGION"
+    s3_region_name: "$S3_REGION_NAME"
 EOF2
 fi
 


### PR DESCRIPTION
## Summary
- allow `docker/fetch_litellm_settings.sh` to skip SSM when AWS creds missing or `SKIP_SSM_FETCH=1`
- fall back to environment variables or defaults for LOG_LEVEL and PostgreSQL settings
- document skipping SSM fetch and overriding defaults in `docker/README.md`

## Testing
- `pre-commit run --files docker/fetch_litellm_settings.sh docker/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68aa297ec4008321a39f3e958947194f