### PR TITLE
refactor: isolate premium auth check

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
@@ -114,7 +114,7 @@ class GenericAPILogger(CustomBatchLogger):
         Raises:
             Raises a NON Blocking verbose_logger.exception if an error occurs
         """
-        from litellm.proxy.utils import _premium_user_check
+        from litellm.proxy.auth.premium import _premium_user_check
 
         _premium_user_check()
 
@@ -153,7 +153,7 @@ class GenericAPILogger(CustomBatchLogger):
         - Creates a StandardLoggingPayload
         - Adds to batch queue
         """
-        from litellm.proxy.utils import _premium_user_check
+        from litellm.proxy.auth.premium import _premium_user_check
 
         _premium_user_check()
 

--- a/litellm/integrations/gcs_pubsub/pub_sub.py
+++ b/litellm/integrations/gcs_pubsub/pub_sub.py
@@ -44,7 +44,7 @@ class GcsPubSubLogger(CustomBatchLogger):
             topic_id (str): Pub/Sub topic ID
             credentials_path (str, optional): Path to Google Cloud credentials JSON file
         """
-        from litellm.proxy.utils import _premium_user_check
+        from litellm.proxy.auth.premium import _premium_user_check
 
         _premium_user_check()
 
@@ -111,7 +111,7 @@ class GcsPubSubLogger(CustomBatchLogger):
         from litellm.proxy.spend_tracking.spend_tracking_utils import (
             get_logging_payload,
         )
-        from litellm.proxy.utils import _premium_user_check
+        from litellm.proxy.auth.premium import _premium_user_check
 
         _premium_user_check()
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, Request, status
 from litellm import Router, provider_list
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
-from litellm.proxy.utils import _premium_user_check
+from litellm.proxy.auth.premium import _premium_user_check
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 
 

--- a/litellm/proxy/auth/premium.py
+++ b/litellm/proxy/auth/premium.py
@@ -1,0 +1,16 @@
+from fastapi import HTTPException
+from litellm.proxy._types import CommonProxyErrors
+
+
+def _premium_user_check():
+    """Raises an HTTPException if the user is not a premium user"""
+    from litellm.proxy.proxy_server import premium_user
+
+    if not premium_user:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "This feature is only available for LiteLLM Enterprise users. "
+                f"{CommonProxyErrors.not_premium_user.value}"
+            },
+        )

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1008,7 +1008,7 @@ def _add_guardrails_from_key_or_team_metadata(
         metadata_variable_name: The name of the metadata field in data
 
     """
-    from litellm.proxy.utils import _premium_user_check
+    from litellm.proxy.auth.premium import _premium_user_check
 
     for _management_object_metadata in [key_metadata, team_metadata]:
         if _management_object_metadata and "guardrails" in _management_object_metadata:

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -7,7 +7,7 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     UserAPIKeyAuth,
 )
-from litellm.proxy.utils import _premium_user_check
+from litellm.proxy.auth.premium import _premium_user_check
 
 
 def _user_has_admin_view(user_api_key_dict: UserAPIKeyAuth) -> bool:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -60,8 +60,8 @@ from litellm.proxy.utils import (
     handle_exception_on_proxy,
     is_valid_api_key,
     jsonify_object,
-    _premium_user_check,
 )
+from litellm.proxy.auth.premium import _premium_user_check
 from litellm.router import Router
 from litellm.secret_managers.main import get_secret
 from litellm.types.router import Deployment

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -41,7 +41,8 @@ from litellm.proxy.management_endpoints.team_endpoints import (
     team_member_add,
     team_member_delete,
 )
-from litellm.proxy.utils import _premium_user_check, handle_exception_on_proxy
+from litellm.proxy.auth.premium import _premium_user_check
+from litellm.proxy.utils import handle_exception_on_proxy
 from litellm.types.proxy.management_endpoints.scim_v2 import *
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -84,9 +84,9 @@ from litellm.proxy.management_helpers.utils import (
 )
 from litellm.proxy.utils import (
     PrismaClient,
-    _premium_user_check,
     handle_exception_on_proxy,
 )
+from litellm.proxy.auth.premium import _premium_user_check
 from litellm.router import Router
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -62,11 +62,11 @@ from litellm.proxy.management_endpoints.types import CustomOpenID
 from litellm.proxy.utils import (
     PrismaClient,
     ProxyLogging,
-    _premium_user_check,
     get_custom_url,
     get_server_root_path,
 )
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
+from litellm.proxy.auth.premium import _premium_user_check
 from litellm.types.proxy.management_endpoints.ui_sso import *
 
 if TYPE_CHECKING:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -25,7 +25,6 @@ from typing import (
 from litellm.constants import DEFAULT_MODEL_CREATED_AT_TIME, MAX_TEAM_LIST_LIMIT
 from litellm.proxy._types import (
     DB_CONNECTION_ERROR_TYPES,
-    CommonProxyErrors,
     ProxyErrorTypes,
     ProxyException,
     SpendLogsMetadata,
@@ -3541,21 +3540,6 @@ def handle_exception_on_proxy(e: Exception) -> ProxyException:
         param=getattr(e, "param", "None"),
         code=status.HTTP_500_INTERNAL_SERVER_ERROR,
     )
-
-
-def _premium_user_check():
-    """
-    Raises an HTTPException if the user is not a premium user
-    """
-    from litellm.proxy.proxy_server import premium_user
-
-    if not premium_user:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": f"This feature is only available for LiteLLM Enterprise users. {CommonProxyErrors.not_premium_user.value}"
-            },
-        )
 
 
 def is_known_model(model: Optional[str], llm_router: Optional[Router]) -> bool:


### PR DESCRIPTION
## Summary
- move `_premium_user_check` to new `proxy.auth.premium` module
- update imports in auth utilities and management endpoints
- drop `_premium_user_check` from `proxy.utils` to avoid circular import

## Testing
- `make lint` *(fails: 311 files would be reformatted)*
- `make lint-ruff`
- `pytest tests/proxy_unit_tests` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2d8e14e883219fb102f6b1376509