### PR TITLE
fix: improve proxy CLI imports

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 else:
     FastAPI = Any
 
-sys.path.append(os.getcwd())
-
 config_filename = "litellm.secrets"
 
 litellm_mode = os.getenv("LITELLM_MODE", "DEV")  # "PRODUCTION", "DEV"
@@ -523,38 +521,22 @@ def run_server(  # noqa: PLR0915
     skip_server_startup,
     keepalive_timeout,
 ):
-    args = locals()
-    if local:
-        from proxy_server import (
+    try:
+        from litellm.proxy.proxy_server import (
             KeyManagementSettings,
             ProxyConfig,
             app,
             save_worker_config,
         )
-    else:
-        try:
-            from .proxy_server import (
-                KeyManagementSettings,
-                ProxyConfig,
-                app,
-                save_worker_config,
-            )
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                f"Missing dependency {e}. Run `pip install 'litellm[proxy]'`"
-            )
-        except ImportError as e:
-            if "litellm[proxy]" in str(e):
-                # user is missing a proxy dependency, ask them to pip install litellm[proxy]
-                raise e
-            else:
-                # this is just a local/relative import error, user git cloned litellm
-                from proxy_server import (
-                    KeyManagementSettings,
-                    ProxyConfig,
-                    app,
-                    save_worker_config,
-                )
+    except ImportError as e:
+        raise ModuleNotFoundError(
+            "Failed to import proxy server. Please install proxy dependencies with "
+            "`pip install 'litellm[proxy]'`."
+            f" Original error: {e}"
+        ) from e
+
+    if local:
+        pass  # backwards compatibility
     if version is True:
         ProxyInitializationHelpers._echo_litellm_version()
         return

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -232,7 +232,7 @@ class TestProxyInitializationHelpers:
         with patch.dict(
             "sys.modules",
             {
-                "proxy_server": MagicMock(
+                "litellm.proxy.proxy_server": MagicMock(
                     app=mock_app,
                     ProxyConfig=mock_proxy_config,
                     KeyManagementSettings=mock_key_mgmt,
@@ -282,7 +282,7 @@ class TestProxyInitializationHelpers:
         with patch.dict(
             "sys.modules",
             {
-                "proxy_server": MagicMock(
+                "litellm.proxy.proxy_server": MagicMock(
                     app=mock_app,
                     ProxyConfig=mock_proxy_config,
                     KeyManagementSettings=mock_key_mgmt,
@@ -313,6 +313,29 @@ class TestProxyInitializationHelpers:
             # Check that the uvicorn.run was called with the timeout_keep_alive parameter
             call_args = mock_uvicorn_run.call_args
             assert call_args[1]["timeout_keep_alive"] == 30
+
+    def test_missing_proxy_dependencies_surfaces_error(self):
+        """Ensure missing proxy dependencies raise helpful error"""
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "litellm.proxy.proxy_server":
+                raise ModuleNotFoundError("fastapi")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            result = runner.invoke(run_server, ["--skip_server_startup"])
+
+        assert result.exit_code != 0
+        assert isinstance(result.exception, ModuleNotFoundError)
+        assert "fastapi" in str(result.exception)
+        assert "pip install 'litellm[proxy]'" in str(result.exception)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_construct_database_url_from_env_vars(self):
@@ -403,7 +426,7 @@ class TestProxyInitializationHelpers:
             with patch.dict(
                 "sys.modules",
                 {
-                    "proxy_server": MagicMock(
+                    "litellm.proxy.proxy_server": MagicMock(
                         app=mock_app,
                         ProxyConfig=mock_proxy_config,
                         KeyManagementSettings=mock_key_mgmt,
@@ -531,7 +554,7 @@ class TestHealthAppFactory:
         with patch.dict(
             "sys.modules",
             {
-                "proxy_server": MagicMock(
+                "litellm.proxy.proxy_server": MagicMock(
                     app=mock_app,
                     ProxyConfig=mock_proxy_config,
                     KeyManagementSettings=mock_key_mgmt,


### PR DESCRIPTION
## Summary
- remove sys.path modification and rely on package imports
- import proxy server via absolute path and surface missing dependency errors
- adjust tests for new import path and cover missing proxy dependency

## Testing
- `pre-commit run --files litellm/proxy/proxy_cli.py tests/test_litellm/proxy/test_proxy_cli.py`
- `pytest tests/test_litellm/proxy/test_proxy_cli.py`
- `python -m litellm.proxy.proxy_cli --help`
- `pip install .[proxy]`
- `litellm --help`


------
https://chatgpt.com/codex/tasks/task_e_68aa3043fa9c8321a9c0e0e8035b55f3