### PR TITLE
refactor proxy chat completion

### DIFF
--- a/litellm/proxy/chat_completion_helpers.py
+++ b/litellm/proxy/chat_completion_helpers.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+import litellm
+from fastapi import status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from litellm.exceptions import RejectedRequestError
+from ._types import UserAPIKeyAuth
+
+
+@dataclass
+class ChatCompletionDependencies:
+    """Container for dependencies used by the chat completion endpoint."""
+
+    proxy_logging_obj: Any
+    llm_router: Any
+    general_settings: Dict[str, Any]
+    proxy_config: Any
+    select_data_generator: Callable[..., Any]
+    user_model: Optional[str]
+    user_temperature: Optional[float]
+    user_request_timeout: Optional[int]
+    user_max_tokens: Optional[int]
+    user_api_base: Optional[str]
+    version: str
+
+
+def validate_chat_request(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate incoming request data for chat completions."""
+    if not isinstance(data, dict):
+        raise ValueError("Invalid request body")
+    return data
+
+
+async def route_chat_request(
+    processor: Any,
+    request: Any,
+    fastapi_response: Any,
+    user_api_key_dict: UserAPIKeyAuth,
+    model: Optional[str],
+    deps: ChatCompletionDependencies,
+) -> Any:
+    """Route the chat completion request through the processor."""
+
+    return await processor.base_process_llm_request(
+        request=request,
+        fastapi_response=fastapi_response,
+        user_api_key_dict=user_api_key_dict,
+        route_type="acompletion",
+        proxy_logging_obj=deps.proxy_logging_obj,
+        llm_router=deps.llm_router,
+        general_settings=deps.general_settings,
+        proxy_config=deps.proxy_config,
+        select_data_generator=deps.select_data_generator,
+        model=model,
+        user_model=deps.user_model,
+        user_temperature=deps.user_temperature,
+        user_request_timeout=deps.user_request_timeout,
+        user_max_tokens=deps.user_max_tokens,
+        user_api_base=deps.user_api_base,
+        version=deps.version,
+    )
+
+
+async def log_chat_completion_error(
+    proxy_logging_obj: Any,
+    user_api_key_dict: UserAPIKeyAuth,
+    error: Exception,
+    data: Dict[str, Any],
+) -> None:
+    """Log a chat completion error."""
+
+    await proxy_logging_obj.post_call_failure_hook(
+        user_api_key_dict=user_api_key_dict,
+        original_exception=error,
+        request_data=data,
+    )
+
+
+def format_chat_completion_response(result: Any) -> Any:
+    """Format the response returned by the processor."""
+    if isinstance(result, BaseModel):
+        return result.model_dump(exclude_none=True, exclude_unset=True)
+    return result
+
+
+async def handle_rejected_request(
+    error: RejectedRequestError,
+    data: Dict[str, Any],
+    user_api_key_dict: UserAPIKeyAuth,
+    select_data_generator: Callable[..., Any],
+) -> Any:
+    """Handle a rejected request by returning an error response."""
+
+    _chat_response = litellm.ModelResponse()
+    _chat_response.choices[0].message.content = error.message  # type: ignore
+
+    if data.get("stream", False) is True:
+        _iterator = litellm.utils.ModelResponseIterator(
+            model_response=_chat_response, convert_to_delta=True
+        )
+        _streaming_response = litellm.CustomStreamWrapper(
+            completion_stream=_iterator,
+            model=data.get("model", ""),
+            custom_llm_provider="cached_response",
+            logging_obj=data.get("litellm_logging_obj", None),
+        )
+        selected_data_generator = select_data_generator(
+            response=_streaming_response,
+            user_api_key_dict=user_api_key_dict,
+            request_data=data,
+        )
+        return StreamingResponse(
+            selected_data_generator,
+            media_type="text/event-stream",
+            status_code=(
+                error.status_code
+                if hasattr(error, "status_code")
+                else status.HTTP_400_BAD_REQUEST
+            ),
+        )
+
+    _usage = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    _chat_response.usage = _usage  # type: ignore
+    return _chat_response

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -209,6 +209,14 @@ from litellm.proxy.common_utils.load_config_utils import (
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     remove_sensitive_info_from_deployment,
 )
+from litellm.proxy.chat_completion_helpers import (
+    ChatCompletionDependencies,
+    format_chat_completion_response,
+    handle_rejected_request,
+    log_chat_completion_error,
+    route_chat_request,
+    validate_chat_request,
+)
 from litellm.proxy.common_utils.proxy_state import ProxyState
 from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
 from litellm.proxy.common_utils.swagger_utils import ERROR_RESPONSES
@@ -3474,6 +3482,24 @@ def select_data_generator(
     )
 
 
+def get_chat_completion_dependencies() -> ChatCompletionDependencies:
+    """Provide dependencies for the chat completion endpoint."""
+
+    return ChatCompletionDependencies(
+        proxy_logging_obj=proxy_logging_obj,
+        llm_router=llm_router,
+        general_settings=general_settings,
+        proxy_config=proxy_config,
+        select_data_generator=select_data_generator,
+        user_model=user_model,
+        user_temperature=user_temperature,
+        user_request_timeout=user_request_timeout,
+        user_max_tokens=user_max_tokens,
+        user_api_base=user_api_base,
+        version=version,
+    )
+
+
 def get_litellm_model_info(model: dict = {}):
     model_info = model.get("model_info", {})
     model_to_lookup = model.get("litellm_params", {}).get("model", None)
@@ -4028,6 +4054,7 @@ async def chat_completion(  # noqa: PLR0915
     fastapi_response: Response,
     model: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    deps: ChatCompletionDependencies = Depends(get_chat_completion_dependencies),
 ):
     """
 
@@ -4052,76 +4079,37 @@ async def chat_completion(  # noqa: PLR0915
     ```
 
     """
-    global general_settings, user_debug, proxy_logging_obj, llm_model_list
-    global user_temperature, user_request_timeout, user_max_tokens, user_api_base
     data = await _read_request_body(request=request)
+    data = validate_chat_request(data)
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        result = await base_llm_response_processor.base_process_llm_request(
+        result = await route_chat_request(
+            processor=base_llm_response_processor,
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
-            route_type="acompletion",
-            proxy_logging_obj=proxy_logging_obj,
-            llm_router=llm_router,
-            general_settings=general_settings,
-            proxy_config=proxy_config,
-            select_data_generator=select_data_generator,
             model=model,
-            user_model=user_model,
-            user_temperature=user_temperature,
-            user_request_timeout=user_request_timeout,
-            user_max_tokens=user_max_tokens,
-            user_api_base=user_api_base,
-            version=version,
+            deps=deps,
         )
-        if isinstance(result, BaseModel):
-            return result.model_dump(exclude_none=True, exclude_unset=True)
-        else:
-            return result
+        return format_chat_completion_response(result)
     except RejectedRequestError as e:
-        _data = e.request_data
-        await proxy_logging_obj.post_call_failure_hook(
+        await log_chat_completion_error(
+            proxy_logging_obj=deps.proxy_logging_obj,
             user_api_key_dict=user_api_key_dict,
-            original_exception=e,
-            request_data=_data,
+            error=e,
+            data=e.request_data,
         )
-        _chat_response = litellm.ModelResponse()
-        _chat_response.choices[0].message.content = e.message  # type: ignore
-
-        if data.get("stream", None) is not None and data["stream"] is True:
-            _iterator = litellm.utils.ModelResponseIterator(
-                model_response=_chat_response, convert_to_delta=True
-            )
-            _streaming_response = litellm.CustomStreamWrapper(
-                completion_stream=_iterator,
-                model=data.get("model", ""),
-                custom_llm_provider="cached_response",
-                logging_obj=data.get("litellm_logging_obj", None),
-            )
-            selected_data_generator = select_data_generator(
-                response=_streaming_response,
-                user_api_key_dict=user_api_key_dict,
-                request_data=_data,
-            )
-
-            return StreamingResponse(
-                selected_data_generator,
-                media_type="text/event-stream",
-                status_code=(
-                    e.status_code
-                    if hasattr(e, "status_code")
-                    else status.HTTP_400_BAD_REQUEST
-                ),
-            )
-        _usage = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-        _chat_response.usage = _usage  # type: ignore
-        return _chat_response
+        return await handle_rejected_request(
+            error=e,
+            data=e.request_data,
+            user_api_key_dict=user_api_key_dict,
+            select_data_generator=deps.select_data_generator,
+        )
     except Exception as e:
         raise await base_llm_response_processor._handle_llm_api_exception(
             e=e,
             user_api_key_dict=user_api_key_dict,
-            proxy_logging_obj=proxy_logging_obj,
+            proxy_logging_obj=deps.proxy_logging_obj,
         )
 
 

--- a/tests/integration/test_chat_completion_endpoint.py
+++ b/tests/integration/test_chat_completion_endpoint.py
@@ -1,0 +1,81 @@
+import asyncio
+import types
+import sys
+import pytest
+from fastapi import FastAPI, APIRouter
+from httpx import AsyncClient, ASGITransport
+from pydantic import BaseModel
+
+sys.modules.setdefault("mcp", types.ModuleType("mcp"))
+sys.modules.setdefault("mcp.client", types.ModuleType("mcp.client"))
+sys.modules.setdefault("mcp.client.streamable_http", types.ModuleType("mcp.client.streamable_http"))
+mcp_types_mod = types.ModuleType("mcp.types")
+setattr(mcp_types_mod, "CallToolRequestParams", object)
+setattr(mcp_types_mod, "CallToolResult", object)
+sys.modules.setdefault("mcp.types", mcp_types_mod)
+fake_rest = types.ModuleType("litellm.proxy._experimental.mcp_server.rest_endpoints")
+fake_rest.router = APIRouter()
+sys.modules["litellm.proxy._experimental.mcp_server.rest_endpoints"] = fake_rest
+fake_manager = types.ModuleType(
+    "litellm.proxy._experimental.mcp_server.mcp_server_manager"
+)
+fake_manager.global_mcp_server_manager = None
+sys.modules["litellm.proxy._experimental.mcp_server.mcp_server_manager"] = fake_manager
+
+from litellm.proxy.proxy_server import (
+    chat_completion,
+    get_chat_completion_dependencies,
+    ProxyBaseLLMRequestProcessing,
+    user_api_key_auth,
+)
+from litellm.proxy.chat_completion_helpers import ChatCompletionDependencies
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class DummyProcessor:
+    def __init__(self, data):
+        self.data = data
+
+    async def base_process_llm_request(self, **kwargs):
+        class DummyResponse(BaseModel):
+            ok: bool
+
+        return DummyResponse(ok=True)
+
+    async def _handle_llm_api_exception(self, **kwargs):
+        raise kwargs["e"]
+
+def test_chat_completion_endpoint(monkeypatch):
+    app = FastAPI()
+    app.post("/chat/completions")(chat_completion)
+
+    app.dependency_overrides[get_chat_completion_dependencies] = lambda: ChatCompletionDependencies(
+        proxy_logging_obj=None,
+        llm_router=None,
+        general_settings={},
+        proxy_config=None,
+        select_data_generator=lambda **kwargs: kwargs["response"],
+        user_model=None,
+        user_temperature=None,
+        user_request_timeout=None,
+        user_max_tokens=None,
+        user_api_base=None,
+        version="test",
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth()
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing", DummyProcessor
+    )
+
+    async def _make_request():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post(
+                "/chat/completions",
+                json={"model": "m", "messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    resp = asyncio.run(_make_request())
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}

--- a/tests/unit/test_chat_completion_helpers.py
+++ b/tests/unit/test_chat_completion_helpers.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic import BaseModel
+from httpx import AsyncClient
+
+import litellm
+from pydantic import BaseModel
+from litellm.exceptions import RejectedRequestError
+from litellm.proxy.chat_completion_helpers import (
+    ChatCompletionDependencies,
+    format_chat_completion_response,
+    handle_rejected_request,
+    log_chat_completion_error,
+    route_chat_request,
+    validate_chat_request,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+def test_validate_chat_request_returns_input():
+    data = {"model": "test"}
+    assert validate_chat_request(data) == data
+
+
+import asyncio
+
+
+def test_route_chat_request_uses_processor():
+    class DummyProcessor:
+        def __init__(self, data):
+            self.data = data
+
+        async def base_process_llm_request(self, **kwargs):
+            return {"ok": True}
+
+    deps = ChatCompletionDependencies(
+        proxy_logging_obj=None,
+        llm_router=None,
+        general_settings={},
+        proxy_config=None,
+        select_data_generator=lambda **kwargs: kwargs["response"],
+        user_model=None,
+        user_temperature=None,
+        user_request_timeout=None,
+        user_max_tokens=None,
+        user_api_base=None,
+        version="test",
+    )
+    processor = DummyProcessor({})
+    result = asyncio.run(
+        route_chat_request(
+            processor=processor,
+            request=None,
+            fastapi_response=None,
+            user_api_key_dict=UserAPIKeyAuth(),
+            model=None,
+            deps=deps,
+        )
+    )
+    assert result == {"ok": True}
+
+
+def test_log_chat_completion_error_called():
+    class DummyLogger:
+        def __init__(self):
+            self.called = False
+
+        async def post_call_failure_hook(self, **kwargs):
+            self.called = True
+
+    logger = DummyLogger()
+    asyncio.run(
+        log_chat_completion_error(
+            proxy_logging_obj=logger,
+            user_api_key_dict=UserAPIKeyAuth(),
+            error=Exception("boom"),
+            data={},
+        )
+    )
+    assert logger.called is True
+
+
+def test_format_chat_completion_response_handles_basemodel():
+    class DummyModel(BaseModel):
+        ok: bool = True
+
+    assert format_chat_completion_response(DummyModel(ok=True)) == {"ok": True}
+    assert format_chat_completion_response({"ok": True}) == {"ok": True}
+
+
+def test_handle_rejected_request_non_streaming():
+    error = RejectedRequestError(
+        message="bad",
+        model="m",
+        llm_provider="p",
+        request_data={"model": "m", "stream": False},
+    )
+    result = asyncio.run(
+        handle_rejected_request(
+            error=error,
+            data=error.request_data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            select_data_generator=lambda **kwargs: kwargs["response"],
+        )
+    )
+    assert isinstance(result, litellm.ModelResponse)
+    assert result.choices[0].message.content == error.message


### PR DESCRIPTION
## Summary
- extract validation, routing, logging, and response formatting helpers for chat completions
- inject dependencies into chat completion endpoint instead of using globals
- add unit tests for helpers and an integration test for chat completion endpoint

## Testing
- `PYTHONPATH=. pytest tests/unit/test_chat_completion_helpers.py tests/integration/test_chat_completion_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3241343c8321af4e2b106f62ccb0