### PR TITLE
feat(proxy-extras): handle existing prisma migrations

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -33,7 +33,9 @@ docker-compose up
 ```
 
 
-### Docker Run 
+**Note:** LiteLLM now automatically baselines the database if a `_prisma_migrations` table already exists, reducing manual cleanup when redeploying.
+
+### Docker Run
 
 #### Step 1. CREATE config.yaml 
 

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -309,6 +309,18 @@ class ProxyExtrasDBManager:
                             )
                             logger.info("✅ All migrations resolved.")
                             return True
+                        elif 'relation "_prisma_migrations" already exists' in e.stderr:
+                            logger.info(
+                                "Detected existing _prisma_migrations table, creating baseline and resolving all migrations"
+                            )
+                            ProxyExtrasDBManager._create_baseline_migration(
+                                schema_path
+                            )
+                            ProxyExtrasDBManager._resolve_all_migrations(
+                                migrations_dir, schema_path
+                            )
+                            logger.info("✅ All migrations resolved.")
+                            return True
                         elif (
                             "P3018" in e.stderr
                         ):  # PostgreSQL error code for duplicate column

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -1,15 +1,13 @@
-import json
 import os
 import sys
-import httpx
+import subprocess
 import pytest
-import respx
 
-from fastapi.testclient import TestClient
-
+# Add litellm-proxy-extras package to path
 sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../../litellm-proxy-extras")),
+)
 
 from litellm_proxy_extras.utils import ProxyExtrasDBManager
 
@@ -29,4 +27,43 @@ def test_custom_prisma_dir(monkeypatch):
     ## Check if the migrations dir is in the temp directory
     migrations_dir = os.path.join(temp_dir, "migrations")
     assert os.path.exists(migrations_dir)
+
+
+def test_setup_database_auto_baseline(monkeypatch):
+    calls = {"run": 0, "create": 0, "resolve": 0}
+
+    def mock_run(*args, **kwargs):
+        if calls["run"] == 0:
+            calls["run"] += 1
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=args[0],
+                stderr='relation "_prisma_migrations" already exists',
+            )
+        raise AssertionError("subprocess.run called more than once")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    def mock_create_baseline(schema_path):
+        calls["create"] += 1
+        return True
+
+    def mock_resolve_all(migrations_dir, schema_path):
+        calls["resolve"] += 1
+        return True
+
+    monkeypatch.setattr(
+        ProxyExtrasDBManager,
+        "_create_baseline_migration",
+        staticmethod(mock_create_baseline),
+    )
+    monkeypatch.setattr(
+        ProxyExtrasDBManager,
+        "_resolve_all_migrations",
+        staticmethod(mock_resolve_all),
+    )
+
+    assert ProxyExtrasDBManager.setup_database(use_migrate=True) is True
+    assert calls["create"] == 1
+    assert calls["resolve"] == 1
 


### PR DESCRIPTION
## Summary
- handle cases where `_prisma_migrations` table already exists by baselining and resolving migrations
- test auto baselining path for existing `_prisma_migrations`
- document automatic baselining during proxy deployment

## Testing
- `pytest tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa4f393d948321ac703a2f99a3eab9