### PR TITLE
chore: rebrand dashboard to Ameritas LiteLLM

### DIFF
--- a/ui/litellm-dashboard/src/app/layout.tsx
+++ b/ui/litellm-dashboard/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
-const appName = process.env.NEXT_PUBLIC_APP_NAME || "LiteLLM";
+const appName = process.env.NEXT_PUBLIC_APP_NAME || "Ameritas LiteLLM";
 
 export const metadata: Metadata = {
   title: `${appName} Dashboard`,

--- a/ui/litellm-dashboard/src/app/onboarding/page.tsx
+++ b/ui/litellm-dashboard/src/app/onboarding/page.tsx
@@ -117,7 +117,7 @@ export default function Onboarding() {
   return (
     <div className="mx-auto w-full max-w-md mt-10">
       <Card>
-        <Title className="text-sm mb-5 text-center">🚅 LiteLLM</Title>
+        <Title className="text-sm mb-5 text-center">🚅 Ameritas LiteLLM</Title>
         <Title className="text-xl">{action === "reset_password" ? "Reset Password" : "Sign up"}</Title>
         <Text>{action === "reset_password" ? "Reset your password to access Admin UI." : "Claim your user account to login to Admin UI."}</Text>
 

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -117,7 +117,7 @@ export default function CreateKeyPage() {
   const [createClicked, setCreateClicked] = useState<boolean>(false)
   const [authLoading, setAuthLoading] = useState(true)
   const [userID, setUserID] = useState<string | null>(null)
-  const [appName, setAppName] = useState<string>(envAppName || "LiteLLM")
+  const [appName, setAppName] = useState<string>(envAppName || "Ameritas LiteLLM")
 
   const invitation_id = searchParams.get("invitation_id")
 


### PR DESCRIPTION
## Summary
- default dashboard branding now shows Ameritas LiteLLM
- replace remaining LiteLLM strings with Ameritas LiteLLM

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa60c05ec08321a915c6f130c3238f