### PR TITLE
feat(ui): update public model hub branding

### DIFF
--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -45,7 +45,7 @@ interface PublicModelHubProps {
 
 const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
   const [modelHubData, setModelHubData] = useState<ModelGroupInfo[] | null>(null);
-  const [pageTitle, setPageTitle] = useState<string>("LiteLLM Gateway");
+  const [pageTitle, setPageTitle] = useState<string>("Ameritas LiteLLM Gateway");
   const [customDocsDescription, setCustomDocsDescription] = useState<string | null>(null);
   const [litellmVersion, setLitellmVersion] = useState<string>("");
   const [usefulLinks, setUsefulLinks] = useState<Record<string, string>>({});
@@ -500,7 +500,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
             <div className="flex items-center space-x-3 text-sm text-gray-600">
               <span className="flex items-center">
                 <span className="w-4 h-4 mr-2">🔧</span>
-                Built with litellm: v{litellmVersion}
+                Built with Ameritas LiteLLM: v{litellmVersion}
               </span>
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- default page title now "Ameritas LiteLLM Gateway"
- about section shows "Built with Ameritas LiteLLM"

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa6a564a448321852d219be80c67d9