### PR TITLE
feat: add runtime audit log toggle

### DIFF
--- a/docs/my-website/docs/proxy/multiple_admins.md
+++ b/docs/my-website/docs/proxy/multiple_admins.md
@@ -33,6 +33,8 @@ litellm_settings:
   store_audit_logs: false
 ```
 
+You can also toggle this setting from the LiteLLM dashboard under **Logs → Audit Logs** using the **Store Audit Logs** switch.
+
 ### 2. Make a change to an entity
 
 In this example, we will delete a key.

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -859,6 +859,7 @@ LITELLM_SETTINGS_SAFE_DB_OVERRIDES = [
     "default_internal_user_params",
     "public_model_groups",
     "public_model_groups_links",
+    "store_audit_logs",
 ]
 SPECIAL_LITELLM_AUTH_TOKEN = ["ui-token"]
 DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL = int(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1589,11 +1589,11 @@ class PassThroughEndpointResponse(LiteLLMPydanticObjectBase):
 class ConfigFieldUpdate(LiteLLMPydanticObjectBase):
     field_name: str
     field_value: Any
-    config_type: Literal["general_settings"]
+    config_type: str
 
 
 class ConfigFieldDelete(LiteLLMPydanticObjectBase):
-    config_type: Literal["general_settings"]
+    config_type: str
     field_name: str
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8388,44 +8388,61 @@ async def update_config_general_settings(
             detail={"error": CommonProxyErrors.not_allowed_access.value},
         )
 
-    if data.field_name not in ConfigGeneralSettings.model_fields:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Invalid field={} passed in.".format(data.field_name)},
+    if data.config_type == "general_settings":
+        if data.field_name not in ConfigGeneralSettings.model_fields:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Invalid field={} passed in.".format(data.field_name)},
+            )
+
+        try:
+            ConfigGeneralSettings(**{data.field_name: data.field_value})
+        except Exception:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "Invalid type of field value={} passed in.".format(
+                        type(data.field_value),
+                    )
+                },
+            )
+
+        db_param_name = "general_settings"
+        existing = await prisma_client.db.litellm_config.find_first(
+            where={"param_name": db_param_name}
         )
-
-    try:
-        ConfigGeneralSettings(**{data.field_name: data.field_value})
-    except Exception:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "Invalid type of field value={} passed in.".format(
-                    type(data.field_value),
-                )
-            },
+        if existing is None or existing.param_value is None:
+            settings = {}
+        else:
+            settings = dict(existing.param_value)
+    elif data.config_type == "litellm_settings":
+        if data.field_name not in LITELLM_SETTINGS_SAFE_DB_OVERRIDES:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Invalid field={} passed in.".format(data.field_name)},
+            )
+        setattr(litellm, data.field_name, data.field_value)
+        db_param_name = "litellm_settings"
+        existing = await prisma_client.db.litellm_config.find_first(
+            where={"param_name": db_param_name}
         )
-
-    ## get general settings from db
-    db_general_settings = await prisma_client.db.litellm_config.find_first(
-        where={"param_name": "general_settings"}
-    )
-    ### update value
-
-    if db_general_settings is None or db_general_settings.param_value is None:
-        general_settings = {}
+        if existing is None or existing.param_value is None:
+            settings = {}
+        else:
+            settings = dict(existing.param_value)
     else:
-        general_settings = dict(db_general_settings.param_value)
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Invalid config_type passed in."},
+        )
 
-    ## update db
-
-    general_settings[data.field_name] = data.field_value
+    settings[data.field_name] = data.field_value
 
     response = await prisma_client.db.litellm_config.upsert(
-        where={"param_name": "general_settings"},
+        where={"param_name": db_param_name},
         data={
-            "create": {"param_name": "general_settings", "param_value": json.dumps(general_settings)},  # type: ignore
-            "update": {"param_value": json.dumps(general_settings)},  # type: ignore
+            "create": {"param_name": db_param_name, "param_value": json.dumps(settings)},  # type: ignore
+            "update": {"param_value": json.dumps(settings)},  # type: ignore
         },
     )
 
@@ -8441,6 +8458,7 @@ async def update_config_general_settings(
 )
 async def get_config_general_settings(
     field_name: str,
+    config_type: Literal["general_settings", "litellm_settings"] = "general_settings",
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     global prisma_client
@@ -8463,35 +8481,42 @@ async def get_config_general_settings(
             detail={"error": CommonProxyErrors.not_allowed_access.value},
         )
 
-    if field_name not in ConfigGeneralSettings.model_fields:
+    if config_type == "general_settings":
+        if field_name not in ConfigGeneralSettings.model_fields:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Invalid field={} passed in.".format(field_name)},
+            )
+        db_param_name = "general_settings"
+    elif config_type == "litellm_settings":
+        if field_name not in LITELLM_SETTINGS_SAFE_DB_OVERRIDES:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Invalid field={} passed in.".format(field_name)},
+            )
+        db_param_name = "litellm_settings"
+    else:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid field={} passed in.".format(field_name)},
+            detail={"error": "Invalid config_type passed in."},
         )
 
-    ## get general settings from db
     db_general_settings = await prisma_client.db.litellm_config.find_first(
-        where={"param_name": "general_settings"}
+        where={"param_name": db_param_name}
     )
-    ### pop the value
-
     if db_general_settings is None or db_general_settings.param_value is None:
         raise HTTPException(
             status_code=400,
             detail={"error": "Field name={} not in DB".format(field_name)},
         )
+    settings = dict(db_general_settings.param_value)
+    if field_name in settings:
+        return ConfigFieldInfo(field_name=field_name, field_value=settings[field_name])
     else:
-        general_settings = dict(db_general_settings.param_value)
-
-        if field_name in general_settings:
-            return ConfigFieldInfo(
-                field_name=field_name, field_value=general_settings[field_name]
-            )
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail={"error": "Field name={} not in DB".format(field_name)},
-            )
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Field name={} not in DB".format(field_name)},
+        )
 
 
 @router.get(

--- a/tests/test_store_audit_logs.py
+++ b/tests/test_store_audit_logs.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from litellm.constants import LITELLM_SETTINGS_SAFE_DB_OVERRIDES
+
+
+def test_store_audit_logs_override_present():
+    assert "store_audit_logs" in LITELLM_SETTINGS_SAFE_DB_OVERRIDES

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4721,12 +4721,13 @@ export const getPassThroughEndpointsCall = async (accessToken: String) => {
 
 export const getConfigFieldSetting = async (
   accessToken: String,
-  fieldName: string
+  fieldName: string,
+  configType: string = "general_settings"
 ) => {
   try {
     let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/config/field/info?field_name=${fieldName}`
-      : `/config/field/info?field_name=${fieldName}`;
+      ? `${proxyBaseUrl}/config/field/info?field_name=${fieldName}&config_type=${configType}`
+      : `/config/field/info?field_name=${fieldName}&config_type=${configType}`;
 
     //NotificationsManager.info("Requesting model data");
     const response = await fetch(url, {
@@ -4842,7 +4843,8 @@ export const createPassThroughEndpoint = async (
 export const updateConfigFieldSetting = async (
   accessToken: String,
   fieldName: string,
-  fieldValue: any
+  fieldValue: any,
+  configType: string = "general_settings"
 ) => {
   try {
     let url = proxyBaseUrl
@@ -4852,7 +4854,7 @@ export const updateConfigFieldSetting = async (
     let formData = {
       field_name: fieldName,
       field_value: fieldValue,
-      config_type: "general_settings",
+      config_type: configType,
     };
     //NotificationsManager.info("Requesting model data");
     const response = await fetch(url, {

--- a/ui/litellm-dashboard/src/components/view_logs/audit_logs.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/audit_logs.tsx
@@ -2,7 +2,8 @@ import { DataTable } from "./table";
 import moment from "moment";
 import { useRef, useState, useEffect, useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { uiAuditLogsCall, keyListCall } from "../networking";
+import { uiAuditLogsCall, keyListCall, getConfigFieldSetting, updateConfigFieldSetting } from "../networking";
+import { Switch } from "antd";
 import { AuditLogEntry, auditLogColumns } from "./columns";
 import { Text } from "@tremor/react";
 import { Team } from "../key_team_helpers/key_list";
@@ -263,38 +264,32 @@ export default function AuditLogs({
     const end = start + pageSize;
     return completeFilteredLogs.slice(start, end);
   }, [completeFilteredLogs, clientCurrentPage, pageSize]);
+  const [storeAuditLogs, setStoreAuditLogs] = useState<boolean>(false);
 
-  // Check if audit logs are empty (not loading and no data)
-  const showAuditLogsInfo = (!allLogsQuery.data || allLogsQuery.data.length === 0);
+  useEffect(() => {
+    if (!accessToken) return;
+    getConfigFieldSetting(accessToken, "store_audit_logs", "litellm_settings")
+      .then((data) => {
+        if (data && typeof data.field_value === "boolean") {
+          setStoreAuditLogs(data.field_value);
+        }
+      })
+      .catch(() => {});
+  }, [accessToken]);
 
-  // Custom AuditLogsInfoMessage component
-  const AuditLogsInfoMessage = ({ show }: { show: boolean }) => {
-    if (!show) return null;
-    
-    return (
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start mb-6">
-        <div className="text-blue-500 mr-3 flex-shrink-0 mt-0.5">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <line x1="12" y1="16" x2="12" y2="12"></line>
-            <line x1="12" y1="8" x2="12.01" y2="8"></line>
-          </svg>
-        </div>
-        <div>
-          <h4 className="text-sm font-medium text-blue-800">Audit Logs Not Available</h4>
-          <p className="text-sm text-blue-700 mt-1">
-            To enable audit logging, add the following configuration to your Ameritas LiteLLM proxy configuration file:
-          </p>
-          <pre className="mt-2 bg-white p-3 rounded border border-blue-200 text-xs font-mono overflow-auto">
-{`litellm_settings:
-  store_audit_logs: true`}
-          </pre>
-          <p className="text-xs text-blue-700 mt-2">
-            Note: This will only affect new requests after the configuration change and proxy restart.
-          </p>
-        </div>
-      </div>
-    );
+  const handleAuditLogToggle = async (checked: boolean) => {
+    if (!accessToken) return;
+    setStoreAuditLogs(checked);
+    try {
+      await updateConfigFieldSetting(
+        accessToken,
+        "store_audit_logs",
+        checked,
+        "litellm_settings"
+      );
+    } catch (e) {
+      setStoreAuditLogs(!checked);
+    }
   };
 
   const renderSubComponent = useCallback(({ row }: { row: any }) => {
@@ -436,13 +431,14 @@ export default function AuditLogs({
       {/* <FilterComponent options={auditLogFilterOptions} onApplyFilters={handleFilterChange} onResetFilters={handleFilterReset} /> */}
       <div className="bg-white rounded-lg shadow">
         <div className="border-b px-6 py-4">
-        <h1 className="text-xl font-semibold py-4">
-              Audit Logs
-            </h1>
-          
-          {/* Show Audit Logs Info Message when no data */}
-          <AuditLogsInfoMessage show={showAuditLogsInfo} />
-          
+          <div className="flex items-center justify-between">
+            <h1 className="text-xl font-semibold py-4">Audit Logs</h1>
+            <div className="flex items-center gap-2">
+              <span className="text-sm">Store Audit Logs</span>
+              <Switch checked={storeAuditLogs} onChange={handleAuditLogToggle} />
+            </div>
+          </div>
+
           <div className="flex flex-col md:flex-row items-start md:items-center justify-between space-y-4 md:space-y-0">
             
             <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- allow updating `store_audit_logs` at runtime
- wire up audit log toggle in dashboard
- document and test audit log setting

## Testing
- `pytest tests/test_store_audit_logs.py -q`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aab1bc9a548321acaf0e8641624e5e