### PR TITLE
build: allow default admin ui if no enterprise colors

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -8,12 +8,7 @@ echo
 pwd
 
 
-# only run this step for litellm enterprise, we run this if enterprise/enterprise_ui/_enterprise.json exists
-if [ ! -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
-    echo "Admin UI - using default LiteLLM UI"
-    exit 0
-fi
-
+# Build Admin UI
 echo "Building Custom Admin UI..."
 
 # Install dependencies
@@ -46,8 +41,13 @@ nvm install v18.17.0
 nvm use v18.17.0
 npm install -g npm
 
-# copy _enterprise.json from this directory to /ui/litellm-dashboard, and rename it to ui_colors.json
-cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
+# copy enterprise colors if available; otherwise, use default LiteLLM UI
+if [ -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
+    cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
+else
+    echo "Admin UI - using default LiteLLM UI"
+    rm -f ui/litellm-dashboard/ui_colors.json
+fi
 
 # cd in to /ui/litellm-dashboard
 cd ui/litellm-dashboard


### PR DESCRIPTION
## Summary
- build admin ui even when enterprise colors are absent
- copy enterprise colors into dashboard when available

## Testing
- `bash -n docker/build_admin_ui.sh`
- `pytest tests/test_store_audit_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac534f2708321a063254d41f55801