### PR TITLE
feat: add dnf install option for admin ui

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -22,8 +22,17 @@ if [[ "$(uname)" == "Darwin" ]]; then
     brew update
     brew install curl
 else
-    # Assume Linux, try using apt-get
-    if command -v apt-get &> /dev/null; then
+    # Assume Linux, try using available package manager
+    if command -v dnf &> /dev/null; then
+        # Use dnf or yum if available
+        if ! command -v curl &> /dev/null; then
+            dnf -y install curl
+        fi
+    elif command -v yum &> /dev/null; then
+        if ! command -v curl &> /dev/null; then
+            yum -y install curl
+        fi
+    elif command -v apt-get &> /dev/null; then
         apt-get update
         apt-get install -y curl
     elif command -v apk &> /dev/null; then


### PR DESCRIPTION
## Summary
- support dnf/yum as package managers in `build_admin_ui.sh`
- skip installing curl when it already exists

## Testing
- `docker build --target builder -t litellm-builder-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `bash docker/build_admin_ui.sh` *(fails: webpack errors about missing `ui_colors.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68aac7d4daf88321b23ccbc344dabce1