### PR TITLE
chore: enhance admin UI build logging

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -3,9 +3,8 @@
 # # try except this script
 # set -e
 
-# print current dir 
-echo
-pwd
+set -x
+echo "Current working directory: $(pwd)"
 
 
 # Build Admin UI
@@ -58,6 +57,10 @@ else
     rm -f ui/litellm-dashboard/ui_colors.json
 fi
 
+ls -al ui/litellm-dashboard
+echo "Latest commit:"
+git log -1 --oneline
+
 # cd in to /ui/litellm-dashboard
 cd ui/litellm-dashboard
 
@@ -69,3 +72,4 @@ chmod +x ./build_ui.sh
 
 # return to root directory
 cd ../..
+set +x

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -43,7 +43,14 @@ if [ $? -eq 0 ]; then
   # Copy the contents of the output directory to the specified destination
   cp -r ./out/* "$destination_dir"
 
+  echo "Contents of out/:"
+  ls -al out/
+  echo "Contents of $destination_dir:"
+  ls -al "$destination_dir"
+
   echo "Deployment completed."
 else
   echo "Build failed. Deployment aborted."
 fi
+set +x
+echo "build_ui.sh finished"


### PR DESCRIPTION
## Summary
- enable shell tracing and log current directory in Docker admin UI build script
- display dashboard directory, latest commit, and disable tracing on completion
- log UI build outputs and destination copy for verification

## Testing
- `pre-commit run --files docker/build_admin_ui.sh ui/litellm-dashboard/build_ui.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aacd02cf3c8321b789957c424f4e18