### PR TITLE
Copy built UI into runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN ls -la /app
 
 # Copy the built wheel from the builder stage to the runtime stage; assumes only one wheel file is present
 COPY --from=builder /app/dist/*.whl .
+COPY --from=builder /app/litellm/proxy/_experimental/out /app/litellm/proxy/_experimental/out
 COPY --from=builder /wheels/ /wheels/
 
 # Install the built wheel using pip; again using a wildcard if it's the only file


### PR DESCRIPTION
## Summary
- ensure runtime image includes built UI by copying _experimental/out from builder

## Testing
- `pre-commit run --files Dockerfile`
- ⚠️ `docker build --no-cache -t litellm-test .` *(Docker daemon unavailable: Error initializing network controller: failed to register "bridge" driver: Enabling IP forwarding failed: open /proc/sys/net/ipv4/ip_forward: read-only file system)*

------
https://chatgpt.com/codex/tasks/task_e_68aacd2535208321b41fd0e6685fce68