### PR TITLE
Copy built UI into runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN ls -la /app
 
 # Copy the built wheel from the builder stage to the runtime stage; assumes only one wheel file is present
 COPY --from=builder /app/dist/*.whl .
+COPY --from=builder /app/litellm/proxy/_experimental/out /app/litellm/proxy/_experimental/out
 COPY --from=builder /wheels/ /wheels/
 
 # Install the built wheel using pip; again using a wildcard if it's the only file

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -92,6 +92,7 @@ COPY . .
 RUN mkdir -p config && cp litellm_config.yaml config/config.yaml
 COPY docker/fetch_litellm_settings.sh docker/
 COPY --from=builder /app/dist/*.whl .
+COPY --from=builder /app/litellm/proxy/_experimental/out /app/litellm/proxy/_experimental/out
 COPY --from=builder /wheels /wheels
 
 # Install from wheels without contacting PyPI


### PR DESCRIPTION
## Summary
- ensure runtime image includes built UI by copying _experimental/out from builder
- mirror this in Dockerfile.local for local builds

## Testing
- `pre-commit run --files docker/Dockerfile.local`
- ⚠️ `docker build -f docker/Dockerfile.local --no-cache -t litellm-test-local .` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68aacd2535208321b41fd0e6685fce68