### PR TITLE
Install Supervisor via pip in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN chmod +x docker/prod_entrypoint.sh
 
 EXPOSE 4000/tcp
 
-RUN dnf install -y supervisor && dnf clean all
+RUN pip install supervisor --no-cache-dir
 COPY docker/supervisord.conf /etc/supervisord.conf
 
 ENTRYPOINT ["docker/prod_entrypoint.sh"]


### PR DESCRIPTION
## Summary
- replace yum install for supervisor with pip to ensure Supervisor is available during image build

## Testing
- `pre-commit run --files Dockerfile`
- `docker build -t litellm-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68ab04a402b08321a63367e4075eee0d