### PR TITLE
Ensure admin UI build aborts on errors

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# # try except this script
-# set -e
+# try except this script
+set -e
 
 set -x
 echo "Current working directory: $(pwd)"
@@ -61,6 +61,9 @@ ls -al ui/litellm-dashboard
 echo "Latest commit:"
 git log -1 --oneline
 
+# Clean existing Admin UI build output to avoid stale files
+rm -rf litellm/proxy/_experimental/out
+
 # cd in to /ui/litellm-dashboard
 cd ui/litellm-dashboard
 
@@ -68,7 +71,7 @@ cd ui/litellm-dashboard
 chmod +x ./build_ui.sh
 
 # run ./build_ui.sh
-./build_ui.sh
+./build_ui.sh || exit 1
 
 # return to root directory
 cd ../..

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -37,8 +37,9 @@ if [ $? -eq 0 ]; then
   # Specify the destination directory
   destination_dir="../../litellm/proxy/_experimental/out"
 
-  # Remove existing files in the destination directory
-  rm -rf "$destination_dir"/*
+  # Remove existing files in the destination directory to avoid stale files
+  rm -rf "$destination_dir"
+  mkdir -p "$destination_dir"
 
   # Copy the contents of the output directory to the specified destination
   cp -r ./out/* "$destination_dir"
@@ -51,6 +52,7 @@ if [ $? -eq 0 ]; then
   echo "Deployment completed."
 else
   echo "Build failed. Deployment aborted."
+  exit 1
 fi
 set +x
 echo "build_ui.sh finished"


### PR DESCRIPTION
## Summary
- Fail fast during Docker admin UI build using `set -e` and explicit error propagation
- Clean out experimental UI build directory to avoid stale files and propagate failures in UI build script

## Testing
- `bash -n docker/build_admin_ui.sh`
- `bash -n ui/litellm-dashboard/build_ui.sh`
- `./ui/litellm-dashboard/build_ui.sh` *(terminated: build step did not complete within time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9fe56a308321bbdee2148695ded1