### PR TITLE
chore: bump admin UI build to Node 20 LTS

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -45,8 +45,8 @@ else
 fi
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 source ~/.nvm/nvm.sh
-nvm install v18.17.0
-nvm use v18.17.0
+nvm install v20
+nvm use v20
 npm install -g npm
 
 # copy enterprise colors if available; otherwise, use default LiteLLM UI
@@ -54,7 +54,18 @@ if [ -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then
     cp enterprise/enterprise_ui/enterprise_colors.json ui/litellm-dashboard/ui_colors.json
 else
     echo "Admin UI - using default LiteLLM UI"
-    rm -f ui/litellm-dashboard/ui_colors.json
+    cat <<'EOF' > ui/litellm-dashboard/ui_colors.json
+{
+  "brand": {
+    "faint": "#EFF6FF",
+    "muted": "#DBEAFE",
+    "subtle": "#BFDBFE",
+    "DEFAULT": "#3B82F6",
+    "emphasis": "#1D4ED8",
+    "inverted": "#FFFFFF"
+  }
+}
+EOF
 fi
 
 ls -al ui/litellm-dashboard

--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -11,11 +11,11 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Use nvm to set the required Node.js version
-nvm use v18.17.0
+nvm use v20
 
 # Check if nvm use was successful
 if [ $? -ne 0 ]; then
-  echo "Error: Failed to switch to Node.js v18.17.0. Deployment aborted."
+  echo "Error: Failed to switch to Node.js v20. Deployment aborted."
   exit 1
 fi
 

--- a/ui/litellm-dashboard/build_ui_custom_path.sh
+++ b/ui/litellm-dashboard/build_ui_custom_path.sh
@@ -21,11 +21,11 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Use nvm to set the required Node.js version
-nvm use v18.17.0
+nvm use v20
 
 # Check if nvm use was successful
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to switch to Node.js v18.17.0. Deployment aborted."
+    echo "Error: Failed to switch to Node.js v20. Deployment aborted."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- build Admin UI with Node.js v20 instead of v18
- ensure build scripts use Node 20 and generate default colors when enterprise theme is missing

## Testing
- `./docker/build_admin_ui.sh`

------
https://chatgpt.com/codex/tasks/task_e_68abcde9738c8321b09de54feeb73914