### PR TITLE
chore: use node 20 for dashboard build

### DIFF
--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -11,11 +11,12 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Use nvm to set the required Node.js version
-nvm use v20
+NODE_VERSION="v20"
+nvm use $NODE_VERSION
 
 # Check if nvm use was successful
 if [ $? -ne 0 ]; then
-  echo "Error: Failed to switch to Node.js v20. Deployment aborted."
+  echo "Error: Failed to switch to Node.js $NODE_VERSION. Deployment aborted."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- use Node.js v20 via nvm when building the LiteLLM dashboard UI

## Testing
- `bash ui/litellm-dashboard/build_ui.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abd07f8758832184e63fcc66ff0741