### PR TITLE
chore: switch build ui custom script to node 20

### DIFF
--- a/ui/litellm-dashboard/build_ui_custom_path.sh
+++ b/ui/litellm-dashboard/build_ui_custom_path.sh
@@ -21,11 +21,12 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Use nvm to set the required Node.js version
-nvm use v20
+NODE_VERSION="v20"
+nvm use $NODE_VERSION
 
 # Check if nvm use was successful
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to switch to Node.js v20. Deployment aborted."
+    echo "Error: Failed to switch to Node.js $NODE_VERSION. Deployment aborted."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- use NODE_VERSION variable when calling nvm for the dashboard custom build script
- update error message to mention Node 20

## Testing
- `nvm use 20`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abd2140db48321b5b2989356ed2fe2