### PR TITLE
feat: increase node heap for ui build

### DIFF
--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -24,6 +24,9 @@ fi
 echo "Contents of ui_colors.json:"
 cat ui_colors.json
 
+# Increase Node.js heap limit to prevent build worker OOM kills
+export NODE_OPTIONS=--max-old-space-size=4096
+
 # Run npm build
 npm run build
 


### PR DESCRIPTION
## Summary
- increase Node.js heap limit in dashboard build script to avoid worker OOM kills

## Testing
- `bash build_ui.sh`
- `pre-commit run --files ui/litellm-dashboard/build_ui.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abd79d921883218506fcf82a9ca9dd