### PR TITLE
chore: guard admin ui build against missing git metadata

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -70,7 +70,11 @@ fi
 
 ls -al ui/litellm-dashboard
 echo "Latest commit:"
-git log -1 --oneline
+if git rev-parse --git-dir > /dev/null 2>&1; then
+    git log -1 --oneline
+else
+    echo "Git metadata not available"
+fi
 
 # Clean existing Admin UI build output to avoid stale files
 rm -rf litellm/proxy/_experimental/out


### PR DESCRIPTION
## Summary
- avoid failing if git metadata isn't available when building admin UI

## Testing
- `pre-commit run --files docker/build_admin_ui.sh`
- `docker build --file Dockerfile --target builder --progress=plain .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe556efa48321b49ec37f55e8d63d