### PR TITLE
Remove duplicate admin UI build step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,6 @@ RUN pip uninstall jwt -y
 RUN pip uninstall PyJWT -y
 RUN pip install PyJWT==2.9.0 --no-cache-dir
 
-# Build Admin UI
-RUN chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh
-
 # Runtime stage
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 


### PR DESCRIPTION
## Summary
- run admin UI build only once in Dockerfile builder stage

## Testing
- `podman build --target builder -t litellm-builder --build-arg LITELLM_BUILD_IMAGE=python:3.11 .` *(fails: Forbidden pulling base image)*

------
https://chatgpt.com/codex/tasks/task_e_68abe6513b108321b3c2e7feeb937670