### PR TITLE
feat: allow proxy args for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ ARG LITELLM_BUILD_IMAGE=registry.access.redhat.com/ubi9/python-311
 
 # Runtime image
 ARG LITELLM_RUNTIME_IMAGE=registry.access.redhat.com/ubi9/python-311
+
+# Optional proxy configuration
+ARG HTTP_PROXY=""
+ARG HTTPS_PROXY=""
+ARG NO_PROXY="localhost,127.0.0.1"
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 
@@ -11,11 +16,13 @@ WORKDIR /app
 
 USER root
 
-ENV HTTP_PROXY="http://proxy.ameritas.com:8080"
-ENV http_proxy="http://proxy.ameritas.com:8080"
-ENV HTTPS_PROXY="http://proxy.ameritas.com:8080"
-ENV https_proxy="http://proxy.ameritas.com:8080"
-ENV NO_PROXY="localhost,127.0.0.1,registry-1.docker.io"
+# Accept proxy settings at build time
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY}
 
 # Install build dependencies
 RUN dnf -y update && \
@@ -55,11 +62,13 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 # Ensure runtime stage runs as root
 USER root
 
-ENV HTTP_PROXY="http://proxy.ameritas.com:8080"
-ENV http_proxy="http://proxy.ameritas.com:8080"
-ENV HTTPS_PROXY="http://proxy.ameritas.com:8080"
-ENV https_proxy="http://proxy.ameritas.com:8080"
-ENV NO_PROXY="localhost,127.0.0.1,registry-1.docker.io"
+# Accept proxy settings at build time
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY}
 
 # Install runtime dependencies
 RUN dnf -y update && \

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -6,6 +6,18 @@ import Image from '@theme/IdealImage';
 
 You can find the Dockerfile to build litellm proxy [here](https://github.com/BerriAI/litellm/blob/main/Dockerfile)
 
+If your network requires a proxy during the image build, supply the values using build arguments:
+
+```bash
+docker build \
+  --build-arg HTTP_PROXY=http://proxy:8080 \
+  --build-arg HTTPS_PROXY=http://proxy:8080 \
+  --build-arg NO_PROXY=localhost,127.0.0.1 \
+  -t litellm-proxy .
+```
+
+Omit these flags if a proxy is not needed.
+
 ## Quick Start
 
 To start using Litellm, run the following commands in a shell:


### PR DESCRIPTION
## Summary
- allow Dockerfile to accept proxy settings via build args
- document passing proxy build arguments in deployment guide

## Testing
- `pytest test_bulk_update_all_users.py -q`
- `pytest tests/test_store_audit_logs.py -q`
- `docker build -t litellm-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68abe7b99930832197dab1b764e23b37