### PR TITLE
chore: use bundled npm for admin ui build

### DIFF
--- a/docker/build_admin_ui.sh
+++ b/docker/build_admin_ui.sh
@@ -47,7 +47,8 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 source ~/.nvm/nvm.sh
 nvm install v20
 nvm use v20
-npm install -g npm
+# Use npm bundled with Node 20 without upgrading
+# npm install -g npm
 
 # copy enterprise colors if available; otherwise, use default LiteLLM UI
 if [ -f "enterprise/enterprise_ui/enterprise_colors.json" ]; then


### PR DESCRIPTION
## Summary
- avoid redundant npm upgrade in admin ui build

## Testing
- `pre-commit run --files docker/build_admin_ui.sh`
- `npm --version`
- `docker build --target builder -f Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68abe9aae9b88321b7a6adfcc36000c9