### PR TITLE
chore: default dashboard logo to favicon

### DIFF
--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -5,7 +5,7 @@ const nextConfig = {
     assetPrefix: '/litellm-asset-prefix',  // If a server_root_path is set, this will be overridden by runtime injection
     env: {
         // Default logo bundled with the UI; can be overridden at build time
-        NEXT_PUBLIC_LOGO_PATH: '/assets/logos/litellm.jpg',
+        NEXT_PUBLIC_LOGO_PATH: '/favicon.png',
     }
 };
 

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -22,7 +22,7 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessToken }) => {
-  const [logoUrl, setLogoUrl] = useState<string | null>(process.env.NEXT_PUBLIC_LOGO_PATH || null);
+  const [logoUrl, setLogoUrl] = useState<string | null>(process.env.NEXT_PUBLIC_LOGO_PATH || '/favicon.png');
 
   // Load logo URL from backend on mount
   useEffect(() => {
@@ -47,6 +47,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
           }
         } catch (error) {
           console.warn('Failed to load logo settings from backend:', error);
+          setLogoUrl('/favicon.png');
         }
       }
     };


### PR DESCRIPTION
## Summary
- default `NEXT_PUBLIC_LOGO_PATH` to `/favicon.png`
- ensure `ThemeContext` uses `/favicon.png` when unset or fetch fails

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68abff8bbad483219c9451dba6fc3d40