### PR TITLE
fix: resolve default dashboard logo from server root

### DIFF
--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -42,6 +42,8 @@ const Navbar: React.FC<NavbarProps> = ({
 }) => {
   const [logoutUrl, setLogoutUrl] = useState("");
   const { logoUrl } = useTheme();
+  const rootPath = process.env.NEXT_PUBLIC_SERVER_ROOT_PATH || '';
+  const defaultLogoUrl = `${rootPath}/ui/favicon.png`;
 
   useEffect(() => {
     const initializeProxySettings = async () => {
@@ -130,7 +132,7 @@ const Navbar: React.FC<NavbarProps> = ({
           <div className="flex items-center flex-shrink-0">
             <Link href="/" className="flex items-center">
               <Image
-                src={logoUrl || "/favicon.png"}
+                src={logoUrl || defaultLogoUrl}
                 alt="Ameritas LiteLLM Brand"
                 className="h-8 w-8 object-contain"
                 width={32}

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -22,7 +22,9 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessToken }) => {
-  const [logoUrl, setLogoUrl] = useState<string | null>(process.env.NEXT_PUBLIC_LOGO_PATH || '/favicon.png');
+  const rootPath = process.env.NEXT_PUBLIC_SERVER_ROOT_PATH || '';
+  const defaultLogoUrl = `${rootPath}/ui/favicon.png`;
+  const [logoUrl, setLogoUrl] = useState<string | null>(process.env.NEXT_PUBLIC_LOGO_PATH || defaultLogoUrl);
 
   // Load logo URL from backend on mount
   useEffect(() => {
@@ -47,13 +49,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
           }
         } catch (error) {
           console.warn('Failed to load logo settings from backend:', error);
-          setLogoUrl('/favicon.png');
+          setLogoUrl(defaultLogoUrl);
         }
       }
     };
 
     loadLogoSettings();
-  }, [accessToken]);
+  }, [accessToken, defaultLogoUrl]);
 
   return (
     <ThemeContext.Provider value={{ logoUrl, setLogoUrl }}>


### PR DESCRIPTION
## Summary
- derive dashboard logo from `NEXT_PUBLIC_SERVER_ROOT_PATH`
- fall back to `${root}/ui/favicon.png` when logo not configured
- honor the new default logo path in navbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac0fb83b108321a25019ad5c8dd065