### PR TITLE
feat: customizable navbar title

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -262,6 +262,7 @@ export default function CreateKeyPage() {
                 proxySettings={proxySettings}
                 accessToken={accessToken}
                 isPublicPage={false}
+                appName={appName}
               />
               <div className="flex flex-1 overflow-auto">
                 <div className="mt-8">

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -28,6 +28,7 @@ interface NavbarProps {
   proxySettings: any;
   accessToken: string | null;
   isPublicPage: boolean;
+  appName?: string;
 }
 
 const Navbar: React.FC<NavbarProps> = ({
@@ -39,6 +40,7 @@ const Navbar: React.FC<NavbarProps> = ({
   setProxySettings,
   accessToken,
   isPublicPage = false,
+  appName = "Ameritas LiteLLM",
 }) => {
   const [logoutUrl, setLogoutUrl] = useState("");
   const { logoUrl } = useTheme();
@@ -138,7 +140,7 @@ const Navbar: React.FC<NavbarProps> = ({
                 width={32}
                 height={32}
               />
-              <span className="ml-2 text-lg font-semibold">AMERITAS LITELLM</span>
+              <span className="ml-2 text-lg font-medium text-gray-900">{appName}</span>
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
- make navbar brand text configurable with appName prop
- default brand to "Ameritas LiteLLM" and update typography classes
- pass app name from main page to navbar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac10aa3a748321b8c05018a2801379