### PR TITLE
Handle empty SSO settings and add SSO regression tests

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -826,7 +826,7 @@ class SSOAuthenticationHandler:
             RedirectResponse: The redirect response from the SSO provider
         """
         # Google SSO Auth
-        if google_client_id is not None:
+        if google_client_id:
             from fastapi_sso.sso.google import GoogleSSO
 
             google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", None)
@@ -848,7 +848,7 @@ class SSOAuthenticationHandler:
             with google_sso:
                 return await google_sso.get_login_redirect(state=state)
         # Microsoft SSO Auth
-        elif microsoft_client_id is not None:
+        elif microsoft_client_id:
             from fastapi_sso.sso.microsoft import MicrosoftSSO
 
             microsoft_client_secret = os.getenv("MICROSOFT_CLIENT_SECRET", None)
@@ -869,7 +869,7 @@ class SSOAuthenticationHandler:
             )
             with microsoft_sso:
                 return await microsoft_sso.get_login_redirect(state=state)
-        elif generic_client_id is not None:
+        elif generic_client_id:
             from fastapi_sso.sso.base import DiscoveryDocument
             from fastapi_sso.sso.generic import create_provider
 
@@ -954,11 +954,7 @@ class SSOAuthenticationHandler:
         microsoft_client_id: Optional[str] = None,
         generic_client_id: Optional[str] = None,
     ) -> bool:
-        if (
-            google_client_id is not None
-            or microsoft_client_id is not None
-            or generic_client_id is not None
-        ):
+        if google_client_id or microsoft_client_id or generic_client_id:
             return True
         return False
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -495,12 +495,22 @@ async def update_sso_settings(sso_config: SSOConfig):
     # Update environment variables in config and in memory
     sso_data = sso_config.model_dump(exclude_none=True)
     for field_name, value in sso_data.items():
+        if value == "":
+            # treat empty strings as None - remove existing entries
+            if field_name == "user_email":
+                config["general_settings"].pop("proxy_admin_email", None)
+            elif field_name == "ui_access_mode":
+                config["general_settings"].pop("ui_access_mode", None)
+            elif field_name in env_var_mapping:
+                env_var_name = env_var_mapping[field_name]
+                config["environment_variables"].pop(env_var_name, None)
+                os.environ.pop(env_var_name, None)
+            continue
 
         if field_name == "user_email" and value is not None:
             # Store user_email in general_settings instead of environment variables
             config["general_settings"]["proxy_admin_email"] = value
         elif field_name == "ui_access_mode" and value is not None:
-
             config["general_settings"]["ui_access_mode"] = value
         elif field_name in env_var_mapping and value is not None:
             env_var_name = env_var_mapping[field_name]

--- a/tests/test_sso_settings.py
+++ b/tests/test_sso_settings.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import asyncio
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from litellm.types.proxy.management_endpoints.ui_sso import SSOConfig
+from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import update_sso_settings
+from litellm.proxy.management_endpoints import ui_sso
+
+# create dummy mcp modules to avoid optional dependency import errors
+import types
+mcp_module = types.ModuleType("mcp")
+mcp_module.__path__ = []  # mark as package
+mcp_module.ClientSession = object
+mcp_module.StdioServerParameters = object
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.client", types.ModuleType("mcp.client"))
+sys.modules.setdefault("mcp.client.streamable_http", types.ModuleType("mcp.client.streamable_http"))
+mcp_types_module = types.ModuleType("mcp.types")
+mcp_types_module.CallToolRequestParams = object  # dummy attribute
+mcp_types_module.CallToolResult = object
+mcp_types_module.Tool = object
+sys.modules.setdefault("mcp.types", mcp_types_module)
+
+# stub litellm.proxy.proxy_server before it's imported
+proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+config_store = {
+    "environment_variables": {
+        "GOOGLE_CLIENT_ID": "client",
+        "GOOGLE_CLIENT_SECRET": "secret",
+    },
+    "general_settings": {},
+}
+
+class DummyProxyConfig:
+    async def get_config(self):
+        return config_store
+
+    async def save_config(self, new_config):
+        config_store.update(new_config)
+
+    def _encrypt_env_variables(self, environment_variables):
+        return environment_variables
+
+proxy_server.proxy_config = DummyProxyConfig()
+proxy_server.master_key = "sk"
+proxy_server.prisma_client = object()
+proxy_server.user_custom_ui_sso_sign_in_handler = None
+proxy_server.premium_user = True
+sys.modules["litellm.proxy.proxy_server"] = proxy_server
+
+
+def test_sso_key_generate_falls_back_after_clearing_settings():
+    # set up initial SSO env variables
+    os.environ["GOOGLE_CLIENT_ID"] = "client"
+    os.environ["GOOGLE_CLIENT_SECRET"] = "secret"
+
+    # clear settings using API
+    asyncio.run(update_sso_settings(SSOConfig(google_client_id="", google_client_secret="")))
+
+    assert "GOOGLE_CLIENT_ID" not in os.environ
+    assert config_store["environment_variables"] == {}
+
+    app = FastAPI()
+    app.include_router(ui_sso.router)
+    client = TestClient(app)
+
+    response = client.get("/sso/key/generate")
+    assert response.status_code == 200
+    assert "Login" in response.text
+
+
+def test_no_provider_selected_when_ids_removed():
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    assert SSOAuthenticationHandler.should_use_sso_handler(
+        google_client_id="",
+        microsoft_client_id="",
+        generic_client_id="",
+    ) is False


### PR DESCRIPTION
## Summary
- Skip storing blank SSO config values and remove existing env entries
- Use truthy SSO client checks in handler and login redirect
- Add regression tests covering SSO clearing and provider selection

## Testing
- `pytest tests/test_sso_settings.py -q`
- `pytest tests/test_store_audit_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ab39a3483219b8c216e8501293e