### PR TITLE
Sanitize user agent headers for logging

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -213,6 +213,9 @@ greenscaleLogger = None
 lunaryLogger = None
 supabaseClient = None
 deepevalLogger = None
+# Sanitize User-Agent header values
+_USER_AGENT_SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9 \-._/()]")
+_MAX_USER_AGENT_LENGTH = 100
 callback_list: Optional[List[str]] = []
 user_logger_fn = None
 additional_details: Optional[Dict[str, str]] = {}
@@ -4229,15 +4232,23 @@ class StandardLoggingPayloadSetup:
             if "user-agent" in headers:
                 user_agent = headers["user-agent"]
                 if user_agent is not None:
-                    if user_agent_tags is None:
-                        user_agent_tags = []
-                    user_agent_part: Optional[str] = None
-                    if "/" in user_agent:
-                        user_agent_part = user_agent.split("/")[0]
-                    if user_agent_part is not None:
-                        user_agent_tags.append("User-Agent: " + user_agent_part)
-                    if user_agent is not None:
-                        user_agent_tags.append("User-Agent: " + user_agent)
+                    # Remove disallowed characters and enforce max length
+                    sanitized_user_agent = _USER_AGENT_SANITIZE_PATTERN.sub(
+                        "", str(user_agent)
+                    )[:_MAX_USER_AGENT_LENGTH]
+                    if sanitized_user_agent:
+                        if user_agent_tags is None:
+                            user_agent_tags = []
+                        user_agent_part: Optional[str] = None
+                        if "/" in sanitized_user_agent:
+                            user_agent_part = sanitized_user_agent.split("/")[0]
+                        if user_agent_part:
+                            user_agent_tags.append(
+                                "User-Agent: " + user_agent_part
+                            )
+                        user_agent_tags.append(
+                            "User-Agent: " + sanitized_user_agent
+                        )
         return user_agent_tags
 
     @staticmethod

--- a/tests/test_user_agent_tags.py
+++ b/tests/test_user_agent_tags.py
@@ -1,0 +1,17 @@
+from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+
+def test_get_user_agent_tags_truncates_long_user_agent():
+    ua = "myclient/" + "a" * 150
+    tags = StandardLoggingPayloadSetup._get_user_agent_tags({"headers": {"user-agent": ua}})
+    assert tags is not None
+    assert tags[0] == "User-Agent: myclient"
+    expected = ua[:100]
+    assert tags[1] == f"User-Agent: {expected}"
+    assert len(expected) == 100
+
+
+def test_get_user_agent_tags_rejects_malformed_user_agent():
+    ua = "\n\n\r\t"
+    tags = StandardLoggingPayloadSetup._get_user_agent_tags({"headers": {"user-agent": ua}})
+    assert tags is None


### PR DESCRIPTION
## Summary
- sanitize and truncate User-Agent header values before tagging
- test User-Agent tag truncation and rejection of invalid headers

## Testing
- `ruff check litellm/litellm_core_utils/litellm_logging.py tests/test_user_agent_tags.py`
- `python -m pytest tests/test_user_agent_tags.py -q`
- `python -m pytest -q` *(fails: Missing credentials for external services)*


------
https://chatgpt.com/codex/tasks/task_e_68ac3145254c83219e0812ea5aa32caf