### PR TITLE
feat: separate configured and dynamic tags

### DIFF
--- a/docs/my-website/docs/tutorials/tag_management.md
+++ b/docs/my-website/docs/tutorials/tag_management.md
@@ -15,6 +15,13 @@ router_settings:
   enable_tag_filtering: True # 👈 Key Change
 ```
 
+## Configured vs Dynamic Tags
+
+Tags returned by the `/tag/list` endpoint are grouped into:
+
+- **Configured tags** – tags you create in the dashboard to control which models a request may use.
+- **Dynamic tags** – tags detected from request metadata for spend tracking. These show up as read-only in the dashboard and do not restrict models.
+
 ## 1. Create a tag
 
 On the LiteLLM UI, navigate to Experimental > Tag Management > Create Tag.

--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -30,6 +30,7 @@ from litellm.types.tag_management import (
     TagConfig,
     TagDeleteRequest,
     TagInfoRequest,
+    TagListResponse,
     TagNewRequest,
     TagUpdateRequest,
 )
@@ -348,7 +349,7 @@ async def info_tag(
     "/tag/list",
     tags=["tag management"],
     dependencies=[Depends(user_api_key_auth)],
-    response_model=List[TagConfig],
+    response_model=TagListResponse,
 )
 async def list_tags(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -364,7 +365,10 @@ async def list_tags(
     try:
         ## QUERY STORED TAGS ##
         tags_config = await _get_tags_config(prisma_client)
-        list_of_tags = list(tags_config.values())
+        configured_tags = {
+            name: (tag if isinstance(tag, TagConfig) else TagConfig(**tag))
+            for name, tag in tags_config.items()
+        }
 
         ## QUERY DYNAMIC TAGS ##
         dynamic_tags = await prisma_client.db.litellm_dailytagspend.find_many(
@@ -376,8 +380,8 @@ async def list_tags(
             for dynamic_tag in dynamic_tags
         ]
 
-        dynamic_tag_config = [
-            TagConfig(
+        dynamic_tag_config = {
+            tag.tag: TagConfig(
                 name=tag.tag,
                 description="This is just a spend tag that was passed dynamically in a request. It does not control any LLM models.",
                 models=None,
@@ -385,10 +389,12 @@ async def list_tags(
                 updated_at=tag.updated_at.isoformat(),
             )
             for tag in dynamic_tags_list
-            if tag.tag not in tags_config
-        ]
+            if tag.tag not in configured_tags
+        }
 
-        return list_of_tags + dynamic_tag_config
+        return TagListResponse(
+            configured_tags=configured_tags, dynamic_tags=dynamic_tag_config
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/litellm/types/tag_management.py
+++ b/litellm/types/tag_management.py
@@ -33,6 +33,11 @@ class TagInfoRequest(BaseModel):
     names: List[str]
 
 
+class TagListResponse(BaseModel):
+    configured_tags: Dict[str, TagConfig]
+    dynamic_tags: Dict[str, TagConfig]
+
+
 class LiteLLM_DailyTagSpendTable(BaseModel):
     id: str
     tag: str

--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -97,7 +97,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({ accessToken, userRole, user
     }
     const tags = await tagListCall(accessToken)
     setAllTags(
-      Object.values(tags).map((tag: Tag) => ({
+      Object.values(tags.configured_tags).map((tag: Tag) => ({
         label: tag.name,
         value: tag.name,
       })),

--- a/ui/litellm-dashboard/src/components/tag_management/TagSelector.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/TagSelector.tsx
@@ -20,7 +20,7 @@ const TagSelector: React.FC<TagSelectorProps> = ({ onChange, value, className, a
       try {
         const response = await tagListCall(accessToken);
         console.log("List tags response:", response);
-        setTags(Object.values(response));
+        setTags(Object.values(response.configured_tags));
       } catch (error) {
         console.error("Error fetching tags:", error);
       }

--- a/ui/litellm-dashboard/src/components/tag_management/TagTable.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/TagTable.tsx
@@ -34,6 +34,7 @@ interface TagTableProps {
   onEdit: (tag: Tag) => void;
   onDelete: (tagName: string) => void;
   onSelectTag: (tagName: string) => void;
+  readOnly?: boolean;
 }
 
 const TagTable: React.FC<TagTableProps> = ({
@@ -41,6 +42,7 @@ const TagTable: React.FC<TagTableProps> = ({
   onEdit,
   onDelete,
   onSelectTag,
+  readOnly = false,
 }) => {
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: "created_at", desc: true }
@@ -53,17 +55,26 @@ const TagTable: React.FC<TagTableProps> = ({
       cell: ({ row }) => {
         const tag = row.original;
         return (
-          <div className="overflow-hidden">
-            <Tooltip title={tag.name}>
-              <Button
-                size="xs"
-                variant="light"
-                className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5"
-                onClick={() => onSelectTag(tag.name)}
-              >
-                {tag.name}
-              </Button>
-            </Tooltip>
+          <div className="overflow-hidden flex items-center">
+            {readOnly ? (
+              <span className="font-mono text-xs">{tag.name}</span>
+            ) : (
+              <Tooltip title={tag.name}>
+                <Button
+                  size="xs"
+                  variant="light"
+                  className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5"
+                  onClick={() => onSelectTag(tag.name)}
+                >
+                  {tag.name}
+                </Button>
+              </Tooltip>
+            )}
+            {tag.is_dynamic && (
+              <Badge size="xs" className="ml-2" color="gray">
+                Dynamic
+              </Badge>
+            )}
           </div>
         );
       },
@@ -126,7 +137,10 @@ const TagTable: React.FC<TagTableProps> = ({
         );
       },
     },
-    {
+  ];
+
+  if (!readOnly) {
+    columns.push({
       id: "actions",
       header: "",
       cell: ({ row }) => {
@@ -148,8 +162,8 @@ const TagTable: React.FC<TagTableProps> = ({
           </div>
         );
       },
-    },
-  ];
+    });
+  }
 
   const table = useReactTable({
     data,

--- a/ui/litellm-dashboard/src/components/tag_management/index.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/index.tsx
@@ -50,7 +50,8 @@ const TagManagement: React.FC<TagProps> = ({
   userID,
   userRole,
 }) => {
-  const [tags, setTags] = useState<Tag[]>([]);
+  const [configuredTags, setConfiguredTags] = useState<Tag[]>([]);
+  const [dynamicTags, setDynamicTags] = useState<Tag[]>([]);
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
   const [editTag, setEditTag] = useState<boolean>(false);
@@ -65,7 +66,13 @@ const TagManagement: React.FC<TagProps> = ({
     try {
       const response = await tagListCall(accessToken);
       console.log("List tags response:", response);
-      setTags(Object.values(response));
+      setConfiguredTags(Object.values(response.configured_tags));
+      setDynamicTags(
+        Object.values(response.dynamic_tags).map((tag: Tag) => ({
+          ...tag,
+          is_dynamic: true,
+        }))
+      );
     } catch (error) {
       console.error("Error fetching tags:", error);
       NotificationsManager.fromBackend("Error fetching tags: " + error);
@@ -182,7 +189,7 @@ const TagManagement: React.FC<TagProps> = ({
           <Grid numItems={1} className="gap-2 pt-2 pb-2 h-[75vh] w-full mt-2">
             <Col numColSpan={1}>
               <TagTable
-                data={tags}
+                data={configuredTags}
                 onEdit={(tag) => {
                   setSelectedTagId(tag.name);
                   setEditTag(true);
@@ -192,6 +199,23 @@ const TagManagement: React.FC<TagProps> = ({
               />
             </Col>
           </Grid>
+
+          {dynamicTags.length > 0 && (
+            <div className="mt-8">
+              <h2>Dynamic Tags</h2>
+              <Grid numItems={1} className="gap-2 pt-2 pb-2 w-full mt-2">
+                <Col numColSpan={1}>
+                  <TagTable
+                    data={dynamicTags}
+                    onEdit={() => {}}
+                    onDelete={() => {}}
+                    onSelectTag={() => {}}
+                    readOnly
+                  />
+                </Col>
+              </Grid>
+            </div>
+          )}
 
           {/* Create Tag Modal */}
           <Modal

--- a/ui/litellm-dashboard/src/components/tag_management/types.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/types.tsx
@@ -7,6 +7,7 @@ export interface Tag {
   updated_at: string;
   created_by?: string;
   updated_by?: string;
+  is_dynamic?: boolean;
 }
 
 export interface TagInfoRequest {
@@ -30,5 +31,8 @@ export interface TagDeleteRequest {
 }
 
 // The API returns a dictionary of tags where the key is the tag name
-export type TagListResponse = Record<string, Tag>;
-export type TagInfoResponse = Record<string, Tag>; 
+export interface TagListResponse {
+  configured_tags: Record<string, Tag>;
+  dynamic_tags: Record<string, Tag>;
+}
+export type TagInfoResponse = Record<string, Tag>;


### PR DESCRIPTION
## Summary
- return structured tag list separating configured and dynamic tags
- display dynamic tags read-only in dashboard with badge
- document tag categories

## Testing
- `ruff check litellm/proxy/management_endpoints/tag_management_endpoints.py litellm/types/tag_management.py`
- `pytest tests/test_user_agent_tags.py -q` *(fails: AttributeError: type object 'StandardLoggingPayloadSetup' has no attribute '_get_user_agent_tags')*
- `cd ui/litellm-dashboard && npm test` *(fails: Missing script "test")*
- `cd ui/litellm-dashboard && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac35090f408321b47f2c944b447e3a