### PR TITLE
Validate reserved tag names

### DIFF
--- a/docs/my-website/docs/tutorials/tag_management.md
+++ b/docs/my-website/docs/tutorials/tag_management.md
@@ -22,6 +22,13 @@ Tags returned by the `/tag/list` endpoint are grouped into:
 - **Configured tags** – tags you create in the dashboard to control which models a request may use.
 - **Dynamic tags** – tags detected from request metadata for spend tracking. These show up as read-only in the dashboard and do not restrict models.
 
+### Reserved Tag Names
+
+Some tag names are reserved by LiteLLM and cannot be created. Requests to create tags with these names will be rejected.
+
+- `litellm-internal-health-check`
+- Any tag starting with `User-Agent:` or prefixes generated from request headers (for example values from `extra_spend_tag_headers`)
+
 ## 1. Create a tag
 
 On the LiteLLM UI, navigate to Experimental > Tag Management > Create Tag.

--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -17,7 +17,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
+import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -40,6 +42,9 @@ if TYPE_CHECKING:
     from litellm.types.router import Deployment
 
 router = APIRouter()
+
+# Reserved tag prefixes that cannot be used for new tags
+RESERVED_TAG_PREFIXES = ["User-Agent:"]
 
 
 async def _get_model_names(prisma_client, model_ids: list) -> Dict[str, str]:
@@ -172,6 +177,18 @@ async def new_tag(
         raise HTTPException(
             status_code=500, detail=CommonProxyErrors.no_llm_router.value
         )
+    # Reserved tag validation
+    reserved_names = [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]
+    reserved_prefixes = RESERVED_TAG_PREFIXES + [
+        f"{header}:" for header in (litellm.extra_spend_tag_headers or [])
+    ]
+    if tag.name in reserved_names or any(
+        tag.name.startswith(prefix) for prefix in reserved_prefixes
+    ):
+        raise HTTPException(
+            status_code=400, detail=f"Tag {tag.name} is reserved and cannot be used"
+        )
+
     try:
         # Get existing tags config
         tags_config = await _get_tags_config(prisma_client)

--- a/tests/test_reserved_tag_names.py
+++ b/tests/test_reserved_tag_names.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import asyncio
+import os
+import pytest
+from fastapi import HTTPException
+
+# Ensure local package is used
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub proxy_server before importing new_tag
+proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+proxy_server.llm_router = object()
+proxy_server.prisma_client = object()
+sys.modules["litellm.proxy.proxy_server"] = proxy_server
+
+from litellm.proxy.management_endpoints.tag_management_endpoints import new_tag
+from litellm.types.tag_management import TagNewRequest
+from litellm.proxy._types import UserAPIKeyAuth
+import litellm
+
+
+def test_rejects_internal_health_tag():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            new_tag(
+                TagNewRequest(name="litellm-internal-health-check"),
+                UserAPIKeyAuth(user_id="u1"),
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_rejects_user_agent_prefix():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            new_tag(
+                TagNewRequest(name="User-Agent: bad"),
+                UserAPIKeyAuth(user_id="u1"),
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_rejects_extra_header_prefix(monkeypatch):
+    monkeypatch.setattr(litellm, "extra_spend_tag_headers", ["X-Test"])
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            new_tag(
+                TagNewRequest(name="X-Test: value"),
+                UserAPIKeyAuth(user_id="u1"),
+            )
+        )
+    assert exc.value.status_code == 400

--- a/ui/litellm-dashboard/src/components/tag_management/index.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/index.tsx
@@ -238,7 +238,23 @@ const TagManagement: React.FC<TagProps> = ({
               <Form.Item
                 label="Tag Name"
                 name="tag_name"
-                rules={[{ required: true, message: "Please input a tag name" }]}
+                rules={[
+                  { required: true, message: "Please input a tag name" },
+                  {
+                    validator: (_, value) => {
+                      if (!value) return Promise.resolve();
+                      const reservedNames = ["litellm-internal-health-check"];
+                      const reservedPrefixes = ["User-Agent:"];
+                      if (
+                        reservedNames.includes(value) ||
+                        reservedPrefixes.some((p) => value.startsWith(p))
+                      ) {
+                        return Promise.reject("This tag name is reserved");
+                      }
+                      return Promise.resolve();
+                    },
+                  },
+                ]}
               >
                 <TextInput />
               </Form.Item>

--- a/ui/litellm-dashboard/src/components/tag_management/tag_info.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/tag_info.tsx
@@ -92,7 +92,27 @@ const TagInfoView: React.FC<TagInfoViewProps> = ({ tagId, onClose, accessToken, 
       {isEditing ? (
         <Card>
           <Form form={form} onFinish={handleSave} layout="vertical" initialValues={tagDetails}>
-            <Form.Item label="Tag Name" name="name" rules={[{ required: true, message: "Please input a tag name" }]}>
+            <Form.Item
+              label="Tag Name"
+              name="name"
+              rules={[
+                { required: true, message: "Please input a tag name" },
+                {
+                  validator: (_, value) => {
+                    if (!value) return Promise.resolve();
+                    const reservedNames = ["litellm-internal-health-check"];
+                    const reservedPrefixes = ["User-Agent:"];
+                    if (
+                      reservedNames.includes(value) ||
+                      reservedPrefixes.some((p) => value.startsWith(p))
+                    ) {
+                      return Promise.reject("This tag name is reserved");
+                    }
+                    return Promise.resolve();
+                  },
+                },
+              ]}
+            >
               <Input />
             </Form.Item>
 


### PR DESCRIPTION
## Summary
- block creation of reserved tags like `litellm-internal-health-check` and `User-Agent:` prefixes
- document and surface reserved tag validation in dashboard
- test reserved tag name handling

## Testing
- `pre-commit run --files litellm/proxy/management_endpoints/tag_management_endpoints.py docs/my-website/docs/tutorials/tag_management.md ui/litellm-dashboard/src/components/tag_management/index.tsx ui/litellm-dashboard/src/components/tag_management/tag_info.tsx tests/test_reserved_tag_names.py`
- `pytest tests/test_reserved_tag_names.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac36af81188321b217e1d2d25348e0