### PR TITLE
feat: add s3 v2 callback params

### DIFF
--- a/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
@@ -22,7 +22,7 @@ export const callback_map: Record<string, string> = {
   Lago: "lago",
   OpenMeter: "openmeter",
   OTel: "otel",
-  S3: "s3",
+  S3: "s3_v2",
   Arize: "arize",
 }
 
@@ -129,8 +129,15 @@ export const callbackInfo: Record<string, CallbackInfo> = {
     [Callbacks.S3]: {
         logo: `${asset_logos_folder}aws.svg`,
         supports_key_team_logging: false,
-        dynamic_params: {},
-        description: "S3 Bucket (AWS) Logging Integration"
+        dynamic_params: {
+          "s3_bucket_name": "text",
+          "s3_region_name": "text",
+          "s3_aws_access_key_id": "text",
+          "s3_aws_secret_access_key": "password",
+          "s3_path": "text",
+          "s3_endpoint_url": "text",
+        },
+        description: "S3 Bucket (AWS) Logging Integration",
     }
 };
   

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -48,6 +48,7 @@ import FormItem from "antd/es/form/FormItem";
 import {
   callback_map,
   callbackInfo,
+  reverse_callback_map,
   Callbacks,
 } from "./callback_info_helpers";
 import { parseErrorMessage } from "./shared/errorUtils";
@@ -690,21 +691,25 @@ const Settings: React.FC<SettingsPageProps> = ({
             </FormItem>
 
             {selectedCallbackParams &&
-              selectedCallbackParams.map((param) => (
-                <FormItem
-                  label={param}
-                  name={param}
-                  key={param}
-                  rules={[
-                    {
-                      required: true,
-                      message: "Please enter the value for " + param,
-                    },
-                  ]}
-                >
-                  <Input.Password />
-                </FormItem>
-              ))}
+              selectedCallbackParams.map((param) => {
+                const callbackDisplayName = reverse_callback_map[selectedCallback || ''] || selectedCallback;
+                const paramType = callbackInfo[callbackDisplayName]?.dynamic_params?.[param] || 'text';
+                return (
+                  <FormItem
+                    label={param}
+                    name={param}
+                    key={param}
+                    rules={[
+                      {
+                        required: true,
+                        message: "Please enter the value for " + param,
+                      },
+                    ]}
+                  >
+                    {paramType === 'password' ? <Input.Password /> : <Input />}
+                  </FormItem>
+                );
+              })}
 
             <div style={{ textAlign: "right", marginTop: "10px" }}>
               <Button2 htmlType="submit">Save</Button2>
@@ -733,21 +738,25 @@ const Settings: React.FC<SettingsPageProps> = ({
           <>
             {selectedEditCallback &&
               selectedEditCallback.variables &&
-              Object.entries(selectedEditCallback.variables).map(([param]) => (
-                <FormItem 
-                  label={param} 
-                  name={param} 
-                  key={param}
-                  rules={[
-                    {
-                      required: true,
-                      message: `Please enter the value for ${param}`,
-                    },
-                  ]}
-                >
-                  <Input.Password />
-                </FormItem>
-              ))}
+              Object.entries(selectedEditCallback.variables).map(([param]) => {
+                const callbackDisplayName = reverse_callback_map[selectedEditCallback.name] || selectedEditCallback.name;
+                const paramType = callbackInfo[callbackDisplayName]?.dynamic_params?.[param] || 'text';
+                return (
+                  <FormItem
+                    label={param}
+                    name={param}
+                    key={param}
+                    rules={[
+                      {
+                        required: true,
+                        message: `Please enter the value for ${param}`,
+                      },
+                    ]}
+                  >
+                    {paramType === 'password' ? <Input.Password /> : <Input />}
+                  </FormItem>
+                );
+              })}
           </>
 
           <div style={{ textAlign: "right", marginTop: "10px" }}>


### PR DESCRIPTION
## Summary
- map S3 callback to `s3_v2`
- add S3 bucket dynamic params with typed inputs
- render callback-specific params in settings forms

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b804271efc8321801ad59c6b9ead59