### PR TITLE
Graceful handling for missing or invalid proxy config

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
 import httpx
+import yaml
 from dotenv import load_dotenv
 
 if TYPE_CHECKING:
@@ -362,7 +363,21 @@ def load_proxy_config(
             raise ImportError("yaml needs to be imported. Run - `pip install 'litellm[proxy]'`")
 
         proxy_config = ProxyConfig()
-        _config = asyncio.run(proxy_config.get_config(config_file_path=options.config))
+        try:
+            _config = asyncio.run(
+                proxy_config.get_config(config_file_path=options.config)
+            )
+        except FileNotFoundError:
+            click.echo(
+                f"LiteLLM Proxy: Config file not found: {options.config}", err=True
+            )
+            sys.exit(1)
+        except yaml.YAMLError as e:
+            click.echo(
+                f"LiteLLM Proxy: Failed to parse config file {options.config}: {e}",
+                err=True,
+            )
+            sys.exit(1)
 
         litellm_settings = _config.get("litellm_settings", None)
         if (


### PR DESCRIPTION
## Summary
- fail fast when proxy config file is missing or cannot be parsed

## Testing
- `pre-commit run --files litellm/proxy/proxy_cli.py`
- `pytest tests/test_reserved_tag_names.py tests/test_sso_settings.py tests/test_store_audit_logs.py tests/test_user_agent_tags.py` *(fails: ImportError: cannot import name 'llm_router' from 'litellm.proxy.proxy_server')*


------
https://chatgpt.com/codex/tasks/task_e_68b806f059c08321be5d75637d6ca9c0