### PR TITLE
Fix tagListCall return type handling

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6031,7 +6031,7 @@ export const tagListCall = async (
     if (!response.ok) {
       const errorData = await response.text();
       await handleError(errorData);
-      return {};
+      return { configured_tags: {}, dynamic_tags: {} };
     }
 
     const data = await response.json();

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -692,8 +692,10 @@ const Settings: React.FC<SettingsPageProps> = ({
 
             {selectedCallbackParams &&
               selectedCallbackParams.map((param) => {
-                const callbackDisplayName = reverse_callback_map[selectedCallback || ''] || selectedCallback;
-                const paramType = callbackInfo[callbackDisplayName]?.dynamic_params?.[param] || 'text';
+                const callbackDisplayName =
+                  reverse_callback_map[selectedCallback || ''] || selectedCallback || '';
+                const paramType =
+                  callbackInfo[callbackDisplayName]?.dynamic_params?.[param] || 'text';
                 return (
                   <FormItem
                     label={param}


### PR DESCRIPTION
## Summary
- ensure tagListCall always returns an object shaped like TagListResponse
- guard callback display name lookup to keep settings build-safe

## Testing
- `bash build_ui.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8111980fc8321ada4ab3c59f43a26