### PR TITLE
Use dict for litellm_settings in proxy update_config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8289,10 +8289,27 @@ async def update_config(config_info: ConfigYAML):  # noqa: PLR0915
         # update the litellm settings
         if config_info.litellm_settings is not None:
             config.setdefault("litellm_settings", {})
+
             updated_litellm_settings = config_info.litellm_settings
+            try:  # pydantic v2
+                updated_litellm_settings = updated_litellm_settings.model_dump(
+                    exclude_none=True
+                )  # type: ignore
+            except Exception:
+                try:  # pydantic v1
+                    updated_litellm_settings = updated_litellm_settings.dict(
+                        exclude_none=True
+                    )  # type: ignore
+                except Exception:
+                    updated_litellm_settings = {
+                        k: v
+                        for k, v in dict(updated_litellm_settings).items()  # type: ignore
+                        if v is not None
+                    }
+
             config["litellm_settings"] = {
-                **updated_litellm_settings,
                 **config["litellm_settings"],
+                **updated_litellm_settings,
             }
 
             # if litellm.success_callback in updated_litellm_settings and config["litellm_settings"]


### PR DESCRIPTION
## Summary
- convert `config_info.litellm_settings` to a dict with `exclude_none=True` in `update_config`
- merge the resulting settings dict into `config['litellm_settings']`

## Testing
- `python -m ruff check litellm/proxy/proxy_server.py`
- `pytest tests/test_reserved_tag_names.py tests/test_user_agent_tags.py -q`
- `pytest -q` *(fails: Missing credentials for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b82061157c8321a435505479bfc658