### PR TITLE
fix: adjust dashboard logo asset path

### DIFF
--- a/ui/litellm-dashboard/README.md
+++ b/ui/litellm-dashboard/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Hosting under a custom path
+
+The dashboard expects static assets like logos to be served from `/ui/assets/logos/`. If your server mounts the dashboard at a different root path, update the asset path accordingly or ensure that the `/ui` prefix is mounted.

--- a/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
@@ -41,7 +41,7 @@ export const mapDisplayToInternalNames = (displayValues: string[]): string[] => 
   return displayValues.map(value => callback_map[value] || value);
 };
 
-const asset_logos_folder = '/assets/logos/';
+const asset_logos_folder = '/ui/assets/logos/';
 
 interface CallbackInfo {
   logo: string;

--- a/ui/litellm-dashboard/tsconfig.json
+++ b/ui/litellm-dashboard/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.stories.tsx"]
 }


### PR DESCRIPTION
## Summary
- serve dashboard logos under `/ui/assets/logos/`
- document mounting `/ui` for custom server setups
- ignore Storybook files in dashboard build

## Testing
- `pre-commit run --files ui/litellm-dashboard/src/components/callback_info_helpers.tsx ui/litellm-dashboard/README.md ui/litellm-dashboard/tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8220e89008321b5cef87ff875ea08