### PR TITLE
feat: support LiteLLM_Params in proxy model loading

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2480,6 +2480,9 @@ class ProxyConfig:
         ## ADD MODEL LOGIC
         for m in db_models:
             _litellm_params = m.litellm_params
+            if isinstance(_litellm_params, LiteLLM_Params):
+                _litellm_params = _litellm_params.model_dump()
+
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
@@ -2492,10 +2495,9 @@ class ProxyConfig:
                         if len(_value) > 0:
                             _litellm_params[k] = _value
                 _litellm_params = LiteLLM_Params(**_litellm_params)
-
             else:
                 verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. Invalid litellm params. litellm_params={_litellm_params}"
+                    f"Invalid model added to proxy db. Invalid litellm params type={type(_litellm_params)} value={_litellm_params}"
                 )
                 continue  # skip to next model
             _model_info = self.get_model_info_with_id(
@@ -2518,6 +2520,9 @@ class ProxyConfig:
         _model_list: list = []
         for m in new_models:
             _litellm_params = m.litellm_params
+            if isinstance(_litellm_params, LiteLLM_Params):
+                _litellm_params = _litellm_params.model_dump()
+
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
@@ -2526,7 +2531,7 @@ class ProxyConfig:
                 _litellm_params = LiteLLM_Params(**_litellm_params)
             else:
                 verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. Invalid litellm params. litellm_params={_litellm_params}"
+                    f"Invalid model added to proxy db. Invalid litellm params type={type(_litellm_params)} value={_litellm_params}"
                 )
                 continue  # skip to next model
 

--- a/tests/test_proxy_server_litellm_params.py
+++ b/tests/test_proxy_server_litellm_params.py
@@ -1,0 +1,99 @@
+import sys
+import os
+import types
+from types import SimpleNamespace
+import pytest
+from fastapi import APIRouter, FastAPI
+
+# Patch FastAPI to avoid including routers during import
+FastAPI.include_router = lambda self, *args, **kwargs: None
+FastAPI.mount = lambda self, *args, **kwargs: None
+
+# Ensure local package is used
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub experimental MCP modules to avoid optional dependency imports
+stub_rest_endpoints = types.ModuleType("stub_rest_endpoints")
+stub_rest_endpoints.router = APIRouter()
+sys.modules["litellm.proxy._experimental.mcp_server.rest_endpoints"] = stub_rest_endpoints
+
+stub_server = types.ModuleType("stub_server")
+stub_server.app = object()
+sys.modules["litellm.proxy._experimental.mcp_server.server"] = stub_server
+
+stub_tool_registry = types.ModuleType("stub_tool_registry")
+stub_tool_registry.global_mcp_tool_registry = object()
+sys.modules["litellm.proxy._experimental.mcp_server.tool_registry"] = stub_tool_registry
+
+stub_manager = types.ModuleType("stub_mcp_manager")
+stub_manager.global_mcp_server_manager = object()
+sys.modules["litellm.proxy._experimental.mcp_server.mcp_server_manager"] = stub_manager
+
+from litellm.proxy import proxy_server
+from litellm.types.router import LiteLLM_Params
+
+
+class DummyRouter:
+    def __init__(self):
+        self.deployments = []
+
+    def upsert_deployment(self, deployment):
+        self.deployments.append(deployment)
+        return deployment
+
+    def get_model_ids(self):
+        return []
+
+
+def test_add_deployment_accepts_dict_and_litellm_params(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_server.master_key = "test-key"
+    proxy_server.llm_router = DummyRouter()
+
+    proxy_config = proxy_server.ProxyConfig()
+
+    dict_model = SimpleNamespace(
+        model_name="gpt-3.5",
+        litellm_params={"model": "gpt-3.5"},
+        model_info={},
+        model_id="1",
+    )
+
+    pydantic_params = LiteLLM_Params(model="gpt-4")
+    pydantic_model = SimpleNamespace(
+        model_name="gpt-4",
+        litellm_params=pydantic_params,
+        model_info={},
+        model_id="2",
+    )
+
+    added = proxy_config._add_deployment([dict_model, pydantic_model])
+    assert added == 2
+    assert len(proxy_server.llm_router.deployments) == 2
+    assert proxy_server.llm_router.deployments[0].litellm_params.model == "gpt-3.5"
+    assert proxy_server.llm_router.deployments[1].litellm_params.model == "gpt-4"
+
+
+def test_decrypt_model_list_from_db_accepts_dict_and_litellm_params(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_config = proxy_server.ProxyConfig()
+
+    dict_model = SimpleNamespace(
+        model_name="gpt-3.5",
+        litellm_params={"model": "gpt-3.5"},
+        model_info={},
+        model_id="1",
+    )
+
+    pydantic_params = LiteLLM_Params(model="gpt-4")
+    pydantic_model = SimpleNamespace(
+        model_name="gpt-4",
+        litellm_params=pydantic_params,
+        model_info={},
+        model_id="2",
+    )
+
+    models = proxy_config.decrypt_model_list_from_db([dict_model, pydantic_model])
+    assert len(models) == 2
+    assert models[0]["litellm_params"]["model"] == "gpt-3.5"
+    assert models[1]["litellm_params"]["model"] == "gpt-4"


### PR DESCRIPTION
## Summary
- allow `_add_deployment` and `decrypt_model_list_from_db` to accept `LiteLLM_Params`
- improve error logging for invalid `litellm_params` types
- test loading of dict and `LiteLLM_Params` DB records

## Testing
- `pytest tests/test_proxy_server_litellm_params.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b834fc1b388321a251deb0352d758f