### PR TITLE
Handle invalid Google SSO client configuration

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1718,18 +1718,37 @@ class GoogleSSOHandler:
             redirect_uri=redirect_url,
             client_secret=google_client_secret,
         )
+        from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 
         # if user is trying to get the raw sso response for debugging, return the raw sso response
         if return_raw_sso_response:
-            return (
-                await google_sso.verify_and_process(
-                    request=request,
-                    convert_response=False,  # type: ignore
+            try:
+                return (
+                    await google_sso.verify_and_process(
+                        request=request,
+                        convert_response=False,  # type: ignore
+                    )
+                    or {}
                 )
-                or {}
-            )
+            except InvalidClientIdError as e:  # pragma: no cover - defensive
+                verbose_proxy_logger.exception("Google SSO verification failed: %s", e)
+                raise ProxyException(
+                    message="Invalid Google OAuth client configuration. Please verify GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.",
+                    type=ProxyErrorTypes.auth_error,
+                    param="GOOGLE_CLIENT_ID",
+                    code=status.HTTP_400_BAD_REQUEST,
+                )
 
-        result = await google_sso.verify_and_process(request)
+        try:
+            result = await google_sso.verify_and_process(request)
+        except InvalidClientIdError as e:
+            verbose_proxy_logger.exception("Google SSO verification failed: %s", e)
+            raise ProxyException(
+                message="Invalid Google OAuth client configuration. Please verify GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.",
+                type=ProxyErrorTypes.auth_error,
+                param="GOOGLE_CLIENT_ID",
+                code=status.HTTP_400_BAD_REQUEST,
+            )
         return result or {}
 
 

--- a/tests/test_invalid_google_client_id.py
+++ b/tests/test_invalid_google_client_id.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import types
+import asyncio
+import pytest
+from fastapi import status
+from starlette.requests import Request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# create dummy mcp modules to avoid optional dependency import errors
+mcp_module = types.ModuleType("mcp")
+mcp_module.__path__ = []  # mark as package
+mcp_module.ClientSession = object
+mcp_module.StdioServerParameters = object
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.client", types.ModuleType("mcp.client"))
+sys.modules.setdefault("mcp.client.streamable_http", types.ModuleType("mcp.client.streamable_http"))
+mcp_types_module = types.ModuleType("mcp.types")
+mcp_types_module.CallToolRequestParams = object  # dummy attribute
+mcp_types_module.CallToolResult = object
+mcp_types_module.Tool = object
+sys.modules.setdefault("mcp.types", mcp_types_module)
+
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
+from fastapi_sso.sso.google import GoogleSSO
+
+async def _mock_verify_and_process(self, request, convert_response=True):
+    raise InvalidClientIdError()
+
+# patch before importing GoogleSSOHandler
+_original_verify_and_process = GoogleSSO.verify_and_process
+GoogleSSO.verify_and_process = _mock_verify_and_process
+
+from litellm.proxy.management_endpoints.ui_sso import GoogleSSOHandler, ProxyException
+
+
+def test_invalid_google_client_id_returns_clear_error():
+    os.environ["GOOGLE_CLIENT_SECRET"] = "secret"
+
+    request = Request(scope={"type": "http", "headers": []})
+
+    async def _call():
+        await GoogleSSOHandler.get_google_callback_response(
+            request=request,
+            google_client_id="bad_id",
+            redirect_url="http://localhost/callback",
+        )
+
+    with pytest.raises(ProxyException) as exc:
+        asyncio.run(_call())
+
+    assert "GOOGLE_CLIENT_ID" in exc.value.message
+    assert exc.value.code == str(status.HTTP_400_BAD_REQUEST)
+
+    # restore original
+    GoogleSSO.verify_and_process = _original_verify_and_process


### PR DESCRIPTION
## Summary
- handle InvalidClientIdError during Google SSO callback
- add unit test for invalid Google SSO client ID

## Testing
- `pytest tests/test_invalid_google_client_id.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab899a64832183123ed5b9e262ff