### PR TITLE
Handle invalid Microsoft SSO client IDs

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -43,6 +44,7 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken, get_user_object
 from litellm.proxy.auth.auth_utils import _has_user_setup_sso
 from litellm.proxy.auth.handle_jwt import JWTHandler
+from litellm.proxy.auth.premium import _premium_user_check
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.admin_ui_utils import (
     admin_ui_disabled,
@@ -66,7 +68,6 @@ from litellm.proxy.utils import (
     get_server_root_path,
 )
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
-from litellm.proxy.auth.premium import _premium_user_check
 from litellm.types.proxy.management_endpoints.ui_sso import *
 
 if TYPE_CHECKING:
@@ -1439,13 +1440,24 @@ class MicrosoftSSOHandler:
             redirect_uri=redirect_url,
             allow_insecure_http=True,
         )
-        original_msft_result = (
-            await microsoft_sso.verify_and_process(
-                request=request,
-                convert_response=False,  # type: ignore
+        try:
+            original_msft_result = (
+                await microsoft_sso.verify_and_process(
+                    request=request,
+                    convert_response=False,  # type: ignore
+                )
+                or {}
             )
-            or {}
-        )
+        except InvalidClientIdError as e:
+            verbose_proxy_logger.exception(
+                "Microsoft SSO verification failed: %s", e
+            )
+            raise ProxyException(
+                message="Invalid Microsoft OAuth client configuration. Please verify MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET.",
+                type=ProxyErrorTypes.auth_error,
+                param="MICROSOFT_CLIENT_ID",
+                code=status.HTTP_400_BAD_REQUEST,
+            )
 
         user_team_ids = await MicrosoftSSOHandler.get_user_groups_from_graph_api(
             access_token=microsoft_sso.access_token

--- a/tests/test_invalid_microsoft_client_id.py
+++ b/tests/test_invalid_microsoft_client_id.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+import asyncio
+import pytest
+from fastapi import status
+from starlette.requests import Request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# create dummy mcp modules to avoid optional dependency import errors
+mcp_module = types.ModuleType("mcp")
+mcp_module.__path__ = []  # mark as package
+mcp_module.ClientSession = object
+mcp_module.StdioServerParameters = object
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.client", types.ModuleType("mcp.client"))
+sys.modules.setdefault("mcp.client.streamable_http", types.ModuleType("mcp.client.streamable_http"))
+mcp_types_module = types.ModuleType("mcp.types")
+mcp_types_module.CallToolRequestParams = object  # dummy attribute
+mcp_types_module.CallToolResult = object
+mcp_types_module.Tool = object
+sys.modules.setdefault("mcp.types", mcp_types_module)
+
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
+from fastapi_sso.sso.microsoft import MicrosoftSSO
+
+
+async def _mock_verify_and_process(self, request, convert_response=True):
+    raise InvalidClientIdError()
+
+
+_original_verify_and_process = MicrosoftSSO.verify_and_process
+MicrosoftSSO.verify_and_process = _mock_verify_and_process
+
+from litellm.proxy.management_endpoints.ui_sso import MicrosoftSSOHandler, ProxyException
+
+
+def test_invalid_microsoft_client_id_returns_clear_error():
+    os.environ["MICROSOFT_CLIENT_SECRET"] = "secret"
+    os.environ["MICROSOFT_TENANT"] = "tenant"
+
+    request = Request(scope={"type": "http", "headers": []})
+
+    async def _call():
+        await MicrosoftSSOHandler.get_microsoft_callback_response(
+            request=request,
+            microsoft_client_id="bad_id",
+            redirect_url="http://localhost/callback",
+        )
+
+    with pytest.raises(ProxyException) as exc:
+        asyncio.run(_call())
+
+    assert "MICROSOFT_CLIENT_ID" in exc.value.message
+    assert exc.value.code == str(status.HTTP_400_BAD_REQUEST)
+
+    MicrosoftSSO.verify_and_process = _original_verify_and_process
+


### PR DESCRIPTION
## Summary
- handle invalid Microsoft SSO client IDs by raising a clear ProxyException
- test for invalid Microsoft client ID returns 400 instead of 500

## Testing
- `pytest tests/test_invalid_microsoft_client_id.py -q`
- `pre-commit run --files litellm/proxy/management_endpoints/ui_sso.py tests/test_invalid_microsoft_client_id.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8ac9daf448321ab67ac52e69bb511