### PR TITLE
Validate Microsoft SSO env vars before callback

### DIFF
--- a/docs/my-website/docs/proxy/admin_ui_sso.md
+++ b/docs/my-website/docs/proxy/admin_ui_sso.md
@@ -67,15 +67,14 @@ GOOGLE_CLIENT_SECRET=
 
 **Required .env variables on your Proxy**
 ```shell
-MICROSOFT_CLIENT_ID="84583a4d-"
-MICROSOFT_CLIENT_SECRET="nbk8Q~"
-MICROSOFT_TENANT="5a39737
+MICROSOFT_CLIENT_ID="<your-client-id>"
+MICROSOFT_CLIENT_SECRET="<your-client-secret>"
+MICROSOFT_TENANT="<your-tenant-id>"
 ```
-- Set Redirect URI on your App Registration on https://portal.azure.com/
-    - Set a redirect url = `<your proxy base url>/sso/callback`
-    ```shell
-    http://localhost:4000/sso/callback
-    ```
+These variables must be non-empty strings. The redirect URI configured on your App Registration should be `<PROXY_BASE_URL>/sso/callback`, for example:
+```shell
+http://localhost:4000/sso/callback
+```
 
 </TabItem>
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -560,6 +560,7 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
         )
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
+    microsoft_client_secret = os.getenv("MICROSOFT_CLIENT_SECRET", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
     generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
     received_response: Optional[dict] = None
@@ -584,6 +585,22 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
             redirect_url=redirect_url,
         )
     elif microsoft_client_id is not None:
+        # Microsoft SSO requires non-empty client ID/secret and a redirect URI
+        # matching <PROXY_BASE_URL>/sso/callback
+        if (
+            microsoft_client_id.strip() == ""
+            or microsoft_client_secret is None
+            or microsoft_client_secret.strip() == ""
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET must be set to"
+                    " non-empty strings for Microsoft SSO. Configure these environment"
+                    " variables and ensure the redirect URI is <PROXY_BASE_URL>/sso/callback."
+                ),
+            )
+
         result = await MicrosoftSSOHandler.get_microsoft_callback_response(
             request=request,
             microsoft_client_id=microsoft_client_id,

--- a/tests/test_invalid_microsoft_client_id.py
+++ b/tests/test_invalid_microsoft_client_id.py
@@ -33,7 +33,12 @@ async def _mock_verify_and_process(self, request, convert_response=True):
 _original_verify_and_process = MicrosoftSSO.verify_and_process
 MicrosoftSSO.verify_and_process = _mock_verify_and_process
 
-from litellm.proxy.management_endpoints.ui_sso import MicrosoftSSOHandler, ProxyException
+from fastapi import HTTPException
+from litellm.proxy.management_endpoints.ui_sso import (
+    MicrosoftSSOHandler,
+    ProxyException,
+    auth_callback,
+)
 
 
 def test_invalid_microsoft_client_id_returns_clear_error():
@@ -56,4 +61,30 @@ def test_invalid_microsoft_client_id_returns_clear_error():
     assert exc.value.code == str(status.HTTP_400_BAD_REQUEST)
 
     MicrosoftSSO.verify_and_process = _original_verify_and_process
+
+
+def test_auth_callback_requires_msft_env_vars():
+    MicrosoftSSO.verify_and_process = _original_verify_and_process
+
+    proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+    proxy_server.general_settings = {}
+    proxy_server.jwt_handler = object()
+    proxy_server.master_key = "sk"
+    proxy_server.prisma_client = object()
+    proxy_server.user_api_key_cache = object()
+    sys.modules["litellm.proxy.proxy_server"] = proxy_server
+
+    os.environ["MICROSOFT_CLIENT_ID"] = ""
+    os.environ["MICROSOFT_CLIENT_SECRET"] = ""
+
+    request = Request(scope={"type": "http", "headers": []})
+
+    async def _call():
+        await auth_callback(request)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(_call())
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "MICROSOFT_CLIENT_ID" in exc.value.detail
 


### PR DESCRIPTION
## Summary
- validate `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET` in SSO callback
- document required Microsoft SSO variables and redirect URI format
- test Microsoft SSO callback for missing environment variables

## Testing
- `pre-commit run --files litellm/proxy/management_endpoints/ui_sso.py docs/my-website/docs/proxy/admin_ui_sso.md tests/test_invalid_microsoft_client_id.py`
- `pytest tests/test_invalid_microsoft_client_id.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8b3c917a0832184a3f371322f865b