### PR TITLE
Validate Google SSO configuration

### DIFF
--- a/docs/my-website/docs/proxy/admin_ui_sso.md
+++ b/docs/my-website/docs/proxy/admin_ui_sso.md
@@ -43,16 +43,18 @@ On Okta, add the 'callback_url' as `<proxy_base_url>/sso/callback`
 </TabItem>
 <TabItem value="google" label="Google SSO">
 
-- Create a new Oauth 2.0 Client on https://console.cloud.google.com/ 
+- Create a new Oauth 2.0 Client on https://console.cloud.google.com/
 
 **Required .env variables on your Proxy**
 ```shell
 # for Google SSO Login
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+GOOGLE_CLIENT_ID="<your-client-id>.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="<your-client-secret>"
 ```
 
-- Set Redirect URL on your Oauth 2.0 Client on https://console.cloud.google.com/ 
+These must be non-empty strings. `GOOGLE_CLIENT_ID` should end with `.apps.googleusercontent.com` and `GOOGLE_CLIENT_SECRET` must match the secret from your Google Cloud Console.
+
+- Set Redirect URL on your Oauth 2.0 Client on https://console.cloud.google.com/
     - Set a redirect url = `<your proxy base url>/sso/callback`
     ```shell
     https://litellm-production-7002.up.railway.app/sso/callback

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -11,6 +11,7 @@ Has all /sso/* routes
 import asyncio
 import os
 import uuid
+import re
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -562,6 +563,7 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     microsoft_client_secret = os.getenv("MICROSOFT_CLIENT_SECRET", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
+    google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", None)
     generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
     received_response: Optional[dict] = None
     # get url from request
@@ -579,6 +581,27 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     verbose_proxy_logger.info(f"Redirecting to {redirect_url}")
     result = None
     if google_client_id is not None:
+        # Google SSO requires a client ID ending with .apps.googleusercontent.com,
+        # a client secret, and a redirect URI matching <PROXY_BASE_URL>/sso/callback
+        if (
+            google_client_id.strip() == ""
+            or google_client_secret is None
+            or google_client_secret.strip() == ""
+            or re.match(r"^[\w.-]+\.apps\.googleusercontent\.com$", google_client_id)
+            is None
+            or re.match(r"^[A-Za-z0-9-_]{8,}$", google_client_secret) is None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set to valid "
+                    "Google OAuth credentials. Set GOOGLE_CLIENT_ID to your OAuth "
+                    "client ID ending with '.apps.googleusercontent.com', set "
+                    "GOOGLE_CLIENT_SECRET to the client secret, and ensure the "
+                    "redirect URI is <PROXY_BASE_URL>/sso/callback."
+                ),
+            )
+
         result = await GoogleSSOHandler.get_google_callback_response(
             request=request,
             google_client_id=google_client_id,

--- a/tests/test_invalid_google_client_id.py
+++ b/tests/test_invalid_google_client_id.py
@@ -3,7 +3,7 @@ import sys
 import types
 import asyncio
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from starlette.requests import Request
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -32,7 +32,11 @@ async def _mock_verify_and_process(self, request, convert_response=True):
 _original_verify_and_process = GoogleSSO.verify_and_process
 GoogleSSO.verify_and_process = _mock_verify_and_process
 
-from litellm.proxy.management_endpoints.ui_sso import GoogleSSOHandler, ProxyException
+from litellm.proxy.management_endpoints.ui_sso import (
+    GoogleSSOHandler,
+    ProxyException,
+    auth_callback,
+)
 
 
 def test_invalid_google_client_id_returns_clear_error():
@@ -55,3 +59,29 @@ def test_invalid_google_client_id_returns_clear_error():
 
     # restore original
     GoogleSSO.verify_and_process = _original_verify_and_process
+
+
+def test_auth_callback_requires_google_env_vars():
+    GoogleSSO.verify_and_process = _original_verify_and_process
+
+    proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+    proxy_server.general_settings = {}
+    proxy_server.jwt_handler = object()
+    proxy_server.master_key = "sk"
+    proxy_server.prisma_client = object()
+    proxy_server.user_api_key_cache = object()
+    sys.modules["litellm.proxy.proxy_server"] = proxy_server
+
+    os.environ["GOOGLE_CLIENT_ID"] = ""
+    os.environ["GOOGLE_CLIENT_SECRET"] = ""
+
+    request = Request(scope={"type": "http", "headers": []})
+
+    async def _call():
+        await auth_callback(request)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(_call())
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GOOGLE_CLIENT_ID" in exc.value.detail


### PR DESCRIPTION
## Summary
- validate Google SSO client credentials before starting flow
- document Google SSO env vars and redirect URI requirements
- add tests for missing Google SSO credentials

## Testing
- `pytest tests/test_invalid_google_client_id.py -q`
- `ruff check litellm/proxy/management_endpoints/ui_sso.py tests/test_invalid_google_client_id.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8b844fcb88321b6554ee1d6dfc9f1