### PR TITLE
Ensure Google SSO only selected with valid credentials

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -580,12 +580,11 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
 
     verbose_proxy_logger.info(f"Redirecting to {redirect_url}")
     result = None
-    if google_client_id is not None:
+    if google_client_id and google_client_secret:
         # Google SSO requires a client ID ending with .apps.googleusercontent.com,
         # a client secret, and a redirect URI matching <PROXY_BASE_URL>/sso/callback
         if (
             google_client_id.strip() == ""
-            or google_client_secret is None
             or google_client_secret.strip() == ""
             or re.match(r"^[\w.-]+\.apps\.googleusercontent\.com$", google_client_id)
             is None
@@ -867,17 +866,10 @@ class SSOAuthenticationHandler:
             RedirectResponse: The redirect response from the SSO provider
         """
         # Google SSO Auth
-        if google_client_id:
+        google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", None)
+        if google_client_id and google_client_secret:
             from fastapi_sso.sso.google import GoogleSSO
 
-            google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", None)
-            if google_client_secret is None:
-                raise ProxyException(
-                    message="GOOGLE_CLIENT_SECRET not set. Set it in .env file",
-                    type=ProxyErrorTypes.auth_error,
-                    param="GOOGLE_CLIENT_SECRET",
-                    code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                )
             google_sso = GoogleSSO(
                 client_id=google_client_id,
                 client_secret=google_client_secret,
@@ -1881,6 +1873,7 @@ async def debug_sso_callback(request: Request):
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
+    google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", None)
     generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
 
     redirect_url = os.getenv("PROXY_BASE_URL", str(request.base_url))
@@ -1890,7 +1883,7 @@ async def debug_sso_callback(request: Request):
         redirect_url += "/sso/debug/callback"
 
     result = None
-    if google_client_id is not None:
+    if google_client_id and google_client_secret:
         result = await GoogleSSOHandler.get_google_callback_response(
             request=request,
             google_client_id=google_client_id,

--- a/tests/test_google_empty_falls_back_to_microsoft.py
+++ b/tests/test_google_empty_falls_back_to_microsoft.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import types
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# create dummy mcp modules to avoid optional dependency import errors
+mcp_module = types.ModuleType("mcp")
+mcp_module.__path__ = []  # mark as package
+mcp_module.ClientSession = object
+mcp_module.StdioServerParameters = object
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.client", types.ModuleType("mcp.client"))
+sys.modules.setdefault("mcp.client.streamable_http", types.ModuleType("mcp.client.streamable_http"))
+mcp_types_module = types.ModuleType("mcp.types")
+mcp_types_module.CallToolRequestParams = object  # dummy attribute
+mcp_types_module.CallToolResult = object
+mcp_types_module.Tool = object
+sys.modules.setdefault("mcp.types", mcp_types_module)
+
+from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+
+def test_empty_google_credentials_use_microsoft(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "")
+    monkeypatch.setenv("MICROSOFT_CLIENT_ID", "client")
+    monkeypatch.setenv("MICROSOFT_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("MICROSOFT_TENANT", "tenant")
+
+    microsoft_called = {"value": False}
+
+    class DummyMicrosoftSSO:
+        def __init__(self, client_id, client_secret, tenant, redirect_uri, allow_insecure_http=True):
+            pass
+
+        async def get_login_redirect(self, state=None):
+            microsoft_called["value"] = True
+            class DummyResponse:
+                status_code = 307
+            return DummyResponse()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class DummyGoogleSSO:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("GoogleSSO should not be used")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr("fastapi_sso.sso.microsoft.MicrosoftSSO", DummyMicrosoftSSO)
+    monkeypatch.setattr("fastapi_sso.sso.google.GoogleSSO", DummyGoogleSSO)
+
+    response = asyncio.run(
+        SSOAuthenticationHandler.get_sso_login_redirect(
+            redirect_url="http://localhost/sso/callback",
+            microsoft_client_id=os.getenv("MICROSOFT_CLIENT_ID"),
+            google_client_id=os.getenv("GOOGLE_CLIENT_ID"),
+        )
+    )
+
+    assert microsoft_called["value"] is True
+    assert response.status_code == 307

--- a/tests/test_invalid_google_client_id.py
+++ b/tests/test_invalid_google_client_id.py
@@ -83,5 +83,5 @@ def test_auth_callback_requires_google_env_vars():
     with pytest.raises(HTTPException) as exc:
         asyncio.run(_call())
 
-    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert "GOOGLE_CLIENT_ID" in exc.value.detail
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "GOOGLE_CLIENT_ID" not in exc.value.detail

--- a/tests/test_sso_settings.py
+++ b/tests/test_sso_settings.py
@@ -6,10 +6,6 @@ from starlette.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from litellm.types.proxy.management_endpoints.ui_sso import SSOConfig
-from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import update_sso_settings
-from litellm.proxy.management_endpoints import ui_sso
-
 # create dummy mcp modules to avoid optional dependency import errors
 import types
 mcp_module = types.ModuleType("mcp")
@@ -25,35 +21,42 @@ mcp_types_module.CallToolResult = object
 mcp_types_module.Tool = object
 sys.modules.setdefault("mcp.types", mcp_types_module)
 
-# stub litellm.proxy.proxy_server before it's imported
-proxy_server = types.ModuleType("litellm.proxy.proxy_server")
-config_store = {
-    "environment_variables": {
-        "GOOGLE_CLIENT_ID": "client",
-        "GOOGLE_CLIENT_SECRET": "secret",
-    },
-    "general_settings": {},
-}
 
-class DummyProxyConfig:
-    async def get_config(self):
-        return config_store
+def _setup_proxy_server_stub():
+    proxy_server = types.ModuleType("litellm.proxy.proxy_server")
+    config_store = {
+        "environment_variables": {
+            "GOOGLE_CLIENT_ID": "client",
+            "GOOGLE_CLIENT_SECRET": "secret",
+        },
+        "general_settings": {},
+    }
 
-    async def save_config(self, new_config):
-        config_store.update(new_config)
+    class DummyProxyConfig:
+        async def get_config(self):
+            return config_store
 
-    def _encrypt_env_variables(self, environment_variables):
-        return environment_variables
+        async def save_config(self, new_config):
+            config_store.update(new_config)
 
-proxy_server.proxy_config = DummyProxyConfig()
-proxy_server.master_key = "sk"
-proxy_server.prisma_client = object()
-proxy_server.user_custom_ui_sso_sign_in_handler = None
-proxy_server.premium_user = True
-sys.modules["litellm.proxy.proxy_server"] = proxy_server
+        def _encrypt_env_variables(self, environment_variables):
+            return environment_variables
+
+    proxy_server.proxy_config = DummyProxyConfig()
+    proxy_server.master_key = "sk"
+    proxy_server.prisma_client = object()
+    proxy_server.user_custom_ui_sso_sign_in_handler = None
+    proxy_server.premium_user = True
+    sys.modules["litellm.proxy.proxy_server"] = proxy_server
+    return config_store
 
 
 def test_sso_key_generate_falls_back_after_clearing_settings():
+    config_store = _setup_proxy_server_stub()
+    from litellm.types.proxy.management_endpoints.ui_sso import SSOConfig
+    from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import update_sso_settings
+    from litellm.proxy.management_endpoints import ui_sso
+
     # set up initial SSO env variables
     os.environ["GOOGLE_CLIENT_ID"] = "client"
     os.environ["GOOGLE_CLIENT_SECRET"] = "secret"


### PR DESCRIPTION
## Summary
- require both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` before choosing Google SSO so empty values don’t block Microsoft login
- add regression test to ensure Microsoft SSO is used when Google variables are blank
- adjust existing test expectations for new behavior

## Testing
- `ruff check litellm/proxy/management_endpoints/ui_sso.py tests/test_sso_settings.py tests/test_invalid_google_client_id.py tests/test_google_empty_falls_back_to_microsoft.py`
- `pytest tests/test_invalid_google_client_id.py tests/test_invalid_microsoft_client_id.py tests/test_sso_settings.py tests/test_google_empty_falls_back_to_microsoft.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c995a6cc83219982e9e3ba716e62