### PR TITLE
feat: store litellm params as JSON

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -12,7 +12,6 @@ model/{model_id}/update - PATCH endpoint for model update.
 
 import asyncio
 import datetime
-import json
 import uuid
 from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
@@ -128,16 +127,16 @@ def update_db_model(
         ]
 
     if "litellm_params" in merged_deployment_dict:
-        prisma_compatible_model_dict["litellm_params"] = json.dumps(
-            merged_deployment_dict["litellm_params"]
-        )
+        prisma_compatible_model_dict["litellm_params"] = merged_deployment_dict[
+            "litellm_params"
+        ]
 
     if "model_info" in merged_deployment_dict:
         model_info = merged_deployment_dict["model_info"]
         for key, value in model_info.items():
             if isinstance(value, datetime.datetime):
                 model_info[key] = value.isoformat()
-        prisma_compatible_model_dict["model_info"] = json.dumps(model_info)
+        prisma_compatible_model_dict["model_info"] = model_info
 
     return prisma_compatible_model_dict
 
@@ -280,7 +279,7 @@ async def _add_model_to_db(
     should_create_model_in_db: bool = True,
 ) -> Optional[LiteLLM_ProxyModelTable]:
     # encrypt litellm params #
-    _litellm_params_dict = model_params.litellm_params.dict(exclude_none=True)
+    _litellm_params_dict = model_params.litellm_params.model_dump(exclude_none=True)
     _orignal_litellm_model_name = model_params.litellm_params.model
     for k, v in _litellm_params_dict.items():
         encrypted_value = encrypt_value_helper(
@@ -290,10 +289,12 @@ async def _add_model_to_db(
     _data: dict = {
         "model_id": model_params.model_info.id,
         "model_name": model_params.model_name,
-        "litellm_params": model_params.litellm_params.model_dump_json(exclude_none=True),  # type: ignore
-        "model_info": model_params.model_info.model_dump_json(  # type: ignore
-            exclude_none=True
-        ),
+        "litellm_params": model_params.litellm_params.model_dump(
+            mode="json", exclude_none=True
+        ),  # type: ignore
+        "model_info": model_params.model_info.model_dump(
+            mode="json", exclude_none=True
+        ),  # type: ignore
         "created_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
     }
@@ -659,7 +660,7 @@ async def delete_team_model_alias(
             tasks.append(
                 prisma_client.db.litellm_modeltable.update(
                     where={"id": id},
-                    data={"model_aliases": json.dumps(model_aliases)},
+                    data={"model_aliases": model_aliases},
                 )
             )
     await asyncio.gather(*tasks)
@@ -904,7 +905,7 @@ async def update_model(
                     pass
 
             _data: dict = {
-                "litellm_params": json.dumps(merged_dictionary),  # type: ignore
+                "litellm_params": merged_dictionary,  # type: ignore
                 "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
             }
             model_response = await prisma_client.db.litellm_proxymodeltable.update(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2522,6 +2522,14 @@ class ProxyConfig:
             _litellm_params = m.litellm_params
             if isinstance(_litellm_params, LiteLLM_Params):
                 _litellm_params = _litellm_params.model_dump()
+            elif isinstance(_litellm_params, str):
+                try:
+                    _litellm_params = json.loads(_litellm_params)
+                except Exception:
+                    verbose_proxy_logger.error(
+                        f"Invalid model added to proxy db. Invalid litellm params type={type(_litellm_params)} value={_litellm_params}"
+                    )
+                    continue  # skip to next model
 
             if isinstance(_litellm_params, dict):
                 # decrypt values

--- a/tests/test_proxy_server_litellm_params.py
+++ b/tests/test_proxy_server_litellm_params.py
@@ -1,8 +1,9 @@
 import sys
 import os
 import types
+import json
+import asyncio
 from types import SimpleNamespace
-import pytest
 from fastapi import APIRouter, FastAPI
 
 # Patch FastAPI to avoid including routers during import
@@ -30,7 +31,8 @@ stub_manager.global_mcp_server_manager = object()
 sys.modules["litellm.proxy._experimental.mcp_server.mcp_server_manager"] = stub_manager
 
 from litellm.proxy import proxy_server
-from litellm.types.router import LiteLLM_Params
+from litellm.proxy.management_endpoints import model_management_endpoints
+from litellm.types.router import LiteLLM_Params, Deployment, ModelInfo
 
 
 class DummyRouter:
@@ -97,3 +99,63 @@ def test_decrypt_model_list_from_db_accepts_dict_and_litellm_params(monkeypatch)
     assert len(models) == 2
     assert models[0]["litellm_params"]["model"] == "gpt-3.5"
     assert models[1]["litellm_params"]["model"] == "gpt-4"
+
+
+def test_decrypt_model_list_from_db_accepts_str(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_config = proxy_server.ProxyConfig()
+
+    str_model = SimpleNamespace(
+        model_name="gpt-3.5",
+        litellm_params=json.dumps({"model": "gpt-3.5"}),
+        model_info={},
+        model_id="1",
+    )
+
+    models = proxy_config.decrypt_model_list_from_db([str_model])
+    assert len(models) == 1
+    assert models[0]["litellm_params"]["model"] == "gpt-3.5"
+
+
+def test_models_added_via_management_endpoint_reload_without_invalid_log(
+    monkeypatch, caplog
+):
+    async def _run():
+        monkeypatch.setattr(
+            proxy_server, "encrypt_value_helper", lambda value, new_encryption_key=None: value
+        )
+        monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+        proxy_server.master_key = "test-key"
+        proxy_server.llm_router = DummyRouter()
+
+        class DummyTable:
+            async def create(self, data):
+                return SimpleNamespace(**data)
+
+        class DummyDB:
+            litellm_proxymodeltable = DummyTable()
+
+        prisma_client = SimpleNamespace(db=DummyDB())
+        user_api_key = SimpleNamespace(user_id="user")
+
+        deployment = Deployment(
+            model_name="gpt-3.5",
+            litellm_params=LiteLLM_Params(model="gpt-3.5"),
+            model_info=ModelInfo(id="model-id"),
+        )
+
+        model_response = await model_management_endpoints._add_model_to_db(
+            model_params=deployment,
+            user_api_key_dict=user_api_key,
+            prisma_client=prisma_client,
+        )
+
+        proxy_config = proxy_server.ProxyConfig()
+
+        with caplog.at_level("ERROR"):
+            added = proxy_config._add_deployment([model_response])
+
+        assert added == 1
+        assert "Invalid model added to proxy db" not in caplog.text
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- store litellm params as JSON objects in DB
- parse string litellm params when loading models
- add regression tests for model management reload

## Testing
- `ruff check litellm/proxy/management_endpoints/model_management_endpoints.py litellm/proxy/proxy_server.py tests/test_proxy_server_litellm_params.py`
- `pytest tests/test_proxy_server_litellm_params.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8ccae13808321bee76e66e39872d0