### PR TITLE
refactor: centralize litellm params parsing

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1446,6 +1446,45 @@ class ProxyConfig:
             "litellm_params string is not valid JSON. DB must store litellm_params as JSON."
         )
 
+    @staticmethod
+    def parse_litellm_params(
+        params: Union[str, dict, LiteLLM_Params]
+    ) -> LiteLLM_Params:
+        """Normalize and decrypt ``litellm_params`` into a ``LiteLLM_Params``.
+
+        Accepts a dictionary, JSON-encoded string, or ``LiteLLM_Params``
+        instance. All string values are decrypted using
+        ``decrypt_value_helper``.
+
+        Raises:
+            ValueError: If parsing or decryption fails.
+        """
+
+        if isinstance(params, LiteLLM_Params):
+            params_dict = params.model_dump()
+        elif isinstance(params, str):
+            try:
+                params_dict = json.loads(params)
+            except Exception:
+                params_dict = ProxyConfig._parse_litellm_params_str(params)
+        elif isinstance(params, dict):
+            params_dict = params
+        else:
+            raise ValueError(f"Invalid litellm params type={type(params)}")
+
+        if not isinstance(params_dict, dict):
+            raise ValueError("litellm_params must be a dict")
+
+        for k, v in params_dict.items():
+            if isinstance(v, str):
+                decrypted_value = decrypt_value_helper(value=v, key=k)
+                if decrypted_value is None:
+                    raise ValueError(f"Unable to decrypt value={v}")
+                if len(decrypted_value) > 0:
+                    params_dict[k] = decrypted_value
+
+        return LiteLLM_Params(**params_dict)
+
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
             return False
@@ -2501,7 +2540,6 @@ class ProxyConfig:
         representations like ``"LiteLLM_Params(...)"`` are parsed on a
         best-effort basis and may raise a ``ValueError`` if conversion fails.
         """
-        import base64
 
         if master_key is None or not isinstance(master_key, str):
             raise Exception(
@@ -2514,36 +2552,11 @@ class ProxyConfig:
         added_models = 0
         ## ADD MODEL LOGIC
         for m in db_models:
-            _litellm_params = m.litellm_params
-            if isinstance(_litellm_params, LiteLLM_Params):
-                _litellm_params = _litellm_params.model_dump()
-            elif isinstance(_litellm_params, str):
-                try:
-                    _litellm_params = json.loads(_litellm_params)
-                except Exception:
-                    try:
-                        _litellm_params = self._parse_litellm_params_str(_litellm_params)
-                    except ValueError as e:
-                        verbose_proxy_logger.error(
-                            f"Invalid model added to proxy db. {e} value={_litellm_params}"
-                        )
-                        continue  # skip to next model
-
-            if isinstance(_litellm_params, dict):
-                # decrypt values
-                for k, v in _litellm_params.items():
-                    if isinstance(v, str):
-                        # decrypt value
-                        _value = decrypt_value_helper(value=v, key=k)
-                        if _value is None:
-                            raise Exception("Unable to decrypt value={}".format(v))
-                        # sanity check if string > size 0
-                        if len(_value) > 0:
-                            _litellm_params[k] = _value
-                _litellm_params = LiteLLM_Params(**_litellm_params)
-            else:
+            try:
+                _litellm_params = self.parse_litellm_params(m.litellm_params)
+            except ValueError as e:
                 verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. Invalid litellm params type={type(_litellm_params)} value={_litellm_params}"
+                    f"Invalid model added to proxy db. {e} value={m.litellm_params}"
                 )
                 continue  # skip to next model
             _model_info = self.get_model_info_with_id(
@@ -2571,30 +2584,11 @@ class ProxyConfig:
         """
         _model_list: list = []
         for m in new_models:
-            _litellm_params = m.litellm_params
-            if isinstance(_litellm_params, LiteLLM_Params):
-                _litellm_params = _litellm_params.model_dump()
-            elif isinstance(_litellm_params, str):
-                try:
-                    _litellm_params = json.loads(_litellm_params)
-                except Exception:
-                    try:
-                        _litellm_params = self._parse_litellm_params_str(_litellm_params)
-                    except ValueError as e:
-                        verbose_proxy_logger.error(
-                            f"Invalid model added to proxy db. {e} value={_litellm_params}"
-                        )
-                        continue  # skip to next model
-
-            if isinstance(_litellm_params, dict):
-                # decrypt values
-                for k, v in _litellm_params.items():
-                    decrypted_value = decrypt_value_helper(value=v, key=k)
-                    _litellm_params[k] = decrypted_value
-                _litellm_params = LiteLLM_Params(**_litellm_params)
-            else:
+            try:
+                _litellm_params = self.parse_litellm_params(m.litellm_params)
+            except ValueError as e:
                 verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. Invalid litellm params type={type(_litellm_params)} value={_litellm_params}"
+                    f"Invalid model added to proxy db. {e} value={m.litellm_params}"
                 )
                 continue  # skip to next model
 

--- a/tests/test_proxy_server_litellm_params.py
+++ b/tests/test_proxy_server_litellm_params.py
@@ -47,6 +47,31 @@ class DummyRouter:
         return []
 
 
+def test_parse_litellm_params_accepts_dict(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_config = proxy_server.ProxyConfig()
+    params = proxy_config.parse_litellm_params({"model": "gpt-3.5"})
+    assert isinstance(params, LiteLLM_Params)
+    assert params.model == "gpt-3.5"
+
+
+def test_parse_litellm_params_accepts_json_string(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_config = proxy_server.ProxyConfig()
+    params = proxy_config.parse_litellm_params(json.dumps({"model": "gpt-3.5"}))
+    assert isinstance(params, LiteLLM_Params)
+    assert params.model == "gpt-3.5"
+
+
+def test_parse_litellm_params_accepts_pydantic_obj(monkeypatch):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_config = proxy_server.ProxyConfig()
+    pydantic_params = LiteLLM_Params(model="gpt-3.5")
+    params = proxy_config.parse_litellm_params(pydantic_params)
+    assert isinstance(params, LiteLLM_Params)
+    assert params.model == "gpt-3.5"
+
+
 def test_add_deployment_accepts_dict_and_litellm_params(monkeypatch):
     monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
     proxy_server.master_key = "test-key"


### PR DESCRIPTION
## Summary
- extract repeated LiteLLM_Params parsing into `parse_litellm_params`
- call helper in `_add_deployment` and `decrypt_model_list_from_db`
- cover dict/JSON-string/Pydantic inputs with unit tests

## Testing
- `pytest tests/test_proxy_server_litellm_params.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9031c8cf88321b3d53c14ff185417