### PR TITLE
Skip malformed LiteLLM params in proxy config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1505,7 +1505,10 @@ class ProxyConfig:
                 if len(decrypted_value) > 0:
                     params_dict[k] = decrypted_value
 
-        return LiteLLM_Params(**params_dict)
+        try:
+            return LiteLLM_Params(**params_dict)
+        except Exception as e:
+            raise ValueError(f"Invalid litellm_params: {e}") from e
 
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
@@ -2576,10 +2579,10 @@ class ProxyConfig:
         for m in db_models:
             try:
                 _litellm_params = self.parse_litellm_params(m.litellm_params)
-            except ValueError as e:
+            except ValueError:
                 masked_params = _mask_litellm_params_for_logging(m.litellm_params)
-                verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. {e} value={masked_params}"
+                verbose_proxy_logger.warning(
+                    f"Invalid litellm_params skipped: {masked_params}"
                 )
                 continue  # skip to next model
             _model_info = self.get_model_info_with_id(
@@ -2609,10 +2612,10 @@ class ProxyConfig:
         for m in new_models:
             try:
                 _litellm_params = self.parse_litellm_params(m.litellm_params)
-            except ValueError as e:
+            except ValueError:
                 masked_params = _mask_litellm_params_for_logging(m.litellm_params)
-                verbose_proxy_logger.error(
-                    f"Invalid model added to proxy db. {e} value={masked_params}"
+                verbose_proxy_logger.warning(
+                    f"Invalid litellm_params skipped: {masked_params}"
                 )
                 continue  # skip to next model
 

--- a/tests/test_proxy_server_litellm_params.py
+++ b/tests/test_proxy_server_litellm_params.py
@@ -208,3 +208,25 @@ def test_models_added_via_management_endpoint_reload_without_invalid_log(
         assert "Invalid model added to proxy db" not in caplog.text
 
     asyncio.run(_run())
+
+
+def test_invalid_litellm_params_skipped(monkeypatch, caplog):
+    monkeypatch.setattr(proxy_server, "decrypt_value_helper", lambda value, key: value)
+    proxy_server.master_key = "test-key"
+    proxy_server.llm_router = DummyRouter()
+
+    proxy_config = proxy_server.ProxyConfig()
+
+    invalid_model = SimpleNamespace(
+        model_name="invalid",
+        litellm_params={"unsupported": "value"},  # missing required 'model'
+        model_info={},
+        model_id="1",
+    )
+
+    with caplog.at_level("WARNING"):
+        added = proxy_config._add_deployment([invalid_model])
+
+    assert added == 0
+    assert len(proxy_server.llm_router.deployments) == 0
+    assert "Invalid litellm_params skipped" in caplog.text


### PR DESCRIPTION
## Summary
- wrap LiteLLM_Params construction in try/except to raise a friendly ValueError
- warn and skip models with invalid `litellm_params`
- add regression test for skipping malformed configurations

## Testing
- `pytest tests/test_proxy_server_litellm_params.py::test_invalid_litellm_params_skipped -q`
- `pytest tests/test_proxy_server_litellm_params.py::test_parse_litellm_params_accepts_dict -q`


------
https://chatgpt.com/codex/tasks/task_e_68b905b181b883219cf40ccb2f6798fe