### PR TITLE
feat: support path-style S3 logging URLs

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1337,6 +1337,7 @@ litellm_settings:
     s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY  # AWS Secret Access Key for S3
     s3_path: my-test-path # [OPTIONAL] set path in bucket you want to write logs to
     s3_endpoint_url: https://s3.amazonaws.com  # [OPTIONAL] S3 endpoint URL, if you want to use Backblaze/cloudflare s3 buckets
+    s3_use_path_style: false # [OPTIONAL] Use path-style URLs (https://s3.{region}.amazonaws.com/{bucket}/{key})
 ```
 
 **Step 3**: Start the proxy, make a test request
@@ -1382,6 +1383,7 @@ litellm_settings:
     s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
     s3_path: my-test-path
     s3_endpoint_url: https://s3.amazonaws.com
+    s3_use_path_style: false
     s3_use_team_prefix: true
 ```
 

--- a/docs/my-website/docs/response_api.md
+++ b/docs/my-website/docs/response_api.md
@@ -810,7 +810,8 @@ litellm_settings:
   callbacks: ["s3_v2"]
   s3_callback_params: # learn more https://docs.litellm.ai/docs/proxy/logging#s3-buckets
     s3_bucket_name: litellm-logs   # AWS Bucket Name for S3
-    s3_region_name: us-west-2       
+    s3_region_name: us-west-2
+    s3_use_path_style: false
 
 general_settings:
   cold_storage_custom_logger: s3_v2

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -50,6 +50,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_batch_size: Optional[int] = DEFAULT_S3_BATCH_SIZE,
         s3_config=None,
         s3_use_team_prefix: bool = False,
+        s3_use_path_style: bool = False,
         **kwargs,
     ):
         try:
@@ -81,6 +82,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 s3_config=s3_config,
                 s3_path=s3_path,
                 s3_use_team_prefix=s3_use_team_prefix,
+                s3_use_path_style=s3_use_path_style,
             )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
 
@@ -125,6 +127,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_config=None,
         s3_path: Optional[str] = None,
         s3_use_team_prefix: bool = False,
+        s3_use_path_style: bool = False,
     ):
         """
         Initialize the s3 params for this logging callback
@@ -194,6 +197,10 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             bool(litellm.s3_callback_params.get("s3_use_team_prefix", False))
             or s3_use_team_prefix
         )
+
+        self.s3_use_path_style = bool(
+            litellm.s3_callback_params.get("s3_use_path_style", False)
+        ) or s3_use_path_style
 
         return
 
@@ -276,7 +283,16 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             )
 
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
+            if self.s3_use_path_style:
+                url = (
+                    f"https://s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{self.s3_bucket_name}/{batch_logging_element.s3_object_key}"
+                )
+            else:
+                url = (
+                    f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{batch_logging_element.s3_object_key}"
+                )
 
             if self.s3_endpoint_url:
                 url = self.s3_endpoint_url + "/" + batch_logging_element.s3_object_key
@@ -421,7 +437,16 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             )
 
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
+            if self.s3_use_path_style:
+                url = (
+                    f"https://s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{self.s3_bucket_name}/{batch_logging_element.s3_object_key}"
+                )
+            else:
+                url = (
+                    f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{batch_logging_element.s3_object_key}"
+                )
 
             if self.s3_endpoint_url:
                 url = self.s3_endpoint_url + "/" + batch_logging_element.s3_object_key
@@ -514,7 +539,16 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             )
 
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{s3_object_key}"
+            if self.s3_use_path_style:
+                url = (
+                    f"https://s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{self.s3_bucket_name}/{s3_object_key}"
+                )
+            else:
+                url = (
+                    f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/"
+                    f"{s3_object_key}"
+                )
 
             if self.s3_endpoint_url:
                 url = self.s3_endpoint_url + "/" + s3_object_key

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1546,6 +1546,9 @@ class S3CallbackParams(LiteLLMPydanticObjectBase):
     s3_path: Optional[str] = Field(
         default=None, description="Optional path prefix within the bucket"
     )
+    s3_use_path_style: Optional[bool] = Field(
+        default=False, description="Use path-style addressing for S3 URLs"
+    )
 
 
 class ConfigLiteLLMSettings(LiteLLMPydanticObjectBase):


### PR DESCRIPTION
## Summary
- allow S3Logger to build path-style URLs with `s3_use_path_style`
- document new `s3_use_path_style` option for S3 logging

## Testing
- `ruff check --fix litellm/integrations/s3_v2.py litellm/proxy/_types.py`
- `pytest tests -q` *(fails: ImportError: cannot import name 'llm_router')*

------
https://chatgpt.com/codex/tasks/task_e_68b92c47eb608321bb219902cf7c641b