### PR TITLE
proxy: validate salt key at startup

### DIFF
--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -4,15 +4,25 @@ from typing import Literal, Optional
 
 from litellm._logging import verbose_proxy_logger
 
+_cached_salt_key: Optional[str] = None
 
-def _get_salt_key():
+
+def _get_salt_key() -> str:
+    global _cached_salt_key
+
+    if _cached_salt_key is not None:
+        return _cached_salt_key
+
     from litellm.proxy.proxy_server import master_key
 
-    salt_key = os.getenv("LITELLM_SALT_KEY", None)
+    salt_key = os.getenv("LITELLM_SALT_KEY") or master_key
 
     if salt_key is None:
-        salt_key = master_key
+        raise RuntimeError(
+            "Missing encryption salt key. Set LITELLM_SALT_KEY or provide master_key before startup."
+        )
 
+    _cached_salt_key = salt_key
     return salt_key
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -205,6 +205,7 @@ from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
+    _get_salt_key,
 )
 from litellm.proxy.common_utils.html_forms.ui_login import html_form
 from litellm.proxy.common_utils.http_parsing_utils import (
@@ -601,6 +602,7 @@ async def proxy_startup_event(app: FastAPI):
 
     ## CHECK MASTER KEY IN ENVIRONMENT ##
     master_key = get_secret_str("LITELLM_MASTER_KEY")
+    _get_salt_key()
     ### LOAD CONFIG ###
     worker_config: Optional[Union[str, dict]] = get_secret("WORKER_CONFIG")  # type: ignore
     env_config_yaml: Optional[str] = get_secret_str("CONFIG_FILE_PATH")

--- a/tests/test_salt_key.py
+++ b/tests/test_salt_key.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+
+def reset_cache(monkeypatch, master_key=None):
+    encrypt_decrypt_utils._cached_salt_key = None
+    proxy_server = types.SimpleNamespace(master_key=master_key)
+    sys.modules.pop('litellm.proxy.proxy_server', None)
+    sys.modules['litellm.proxy.proxy_server'] = proxy_server
+    monkeypatch.delenv('LITELLM_SALT_KEY', raising=False)
+    return proxy_server
+
+
+def test_get_salt_key_from_env(monkeypatch):
+    reset_cache(monkeypatch)
+    monkeypatch.setenv('LITELLM_SALT_KEY', 'envkey')
+    assert encrypt_decrypt_utils._get_salt_key() == 'envkey'
+
+
+def test_get_salt_key_from_master_key(monkeypatch):
+    reset_cache(monkeypatch, master_key='mkey')
+    assert encrypt_decrypt_utils._get_salt_key() == 'mkey'


### PR DESCRIPTION
## Summary
- raise clear error when no salt key or master key is configured
- resolve salt key once and cache for lifetime of process
- validate salt key during proxy startup
- add tests for salt key resolution

## Testing
- `ruff check litellm/proxy/common_utils/encrypt_decrypt_utils.py litellm/proxy/proxy_server.py tests/test_salt_key.py`
- `pytest tests/test_salt_key.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93532aa588321aa0b0a31b5906136