### PR TITLE
Handle plaintext in decrypt_value_helper

### DIFF
--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -7,6 +7,14 @@ from litellm._logging import verbose_proxy_logger
 _cached_salt_key: Optional[str] = None
 
 
+def _is_base64(value: str) -> bool:
+    try:
+        base64.b64decode(value, validate=True)
+        return True
+    except Exception:
+        return False
+
+
 def _get_salt_key() -> str:
     global _cached_salt_key
 
@@ -54,6 +62,8 @@ def decrypt_value_helper(
 
     try:
         if isinstance(value, str):
+            if not _is_base64(value):
+                return value
             decoded_b64 = base64.b64decode(value)
             value = decrypt_value(value=decoded_b64, signing_key=signing_key)  # type: ignore
             return value

--- a/tests/test_decrypt_value_helper.py
+++ b/tests/test_decrypt_value_helper.py
@@ -1,0 +1,25 @@
+import base64
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from litellm.proxy.common_utils import encrypt_decrypt_utils
+
+
+def test_is_base64_helper():
+    valid = base64.b64encode(b"hello").decode()
+    assert encrypt_decrypt_utils._is_base64(valid)
+    assert not encrypt_decrypt_utils._is_base64("plain-text")
+
+
+def test_decrypt_plain_text_returns_original_value(monkeypatch, caplog):
+    encrypt_decrypt_utils._cached_salt_key = "testkey"
+    with caplog.at_level("ERROR"):
+        result = encrypt_decrypt_utils.decrypt_value_helper(
+            value="plain-text", key="dummy"
+        )
+    assert result == "plain-text"
+    assert caplog.text == ""
+
+


### PR DESCRIPTION
## Summary
- add `_is_base64` helper to detect base64 strings
- skip decryption for non-base64 values in `decrypt_value_helper`
- test plain-text inputs to ensure no error logs

## Testing
- `pytest tests/test_decrypt_value_helper.py tests/test_salt_key.py`

------
https://chatgpt.com/codex/tasks/task_e_68b937fb26b08321867c5f05f9d88658