### PR TITLE
Verify proxy salt key against stored hash

### DIFF
--- a/db_scripts/update_salt_key_hash.py
+++ b/db_scripts/update_salt_key_hash.py
@@ -1,0 +1,35 @@
+import asyncio
+import hashlib
+import os
+
+from prisma import Prisma
+
+
+async def update_salt_key_hash() -> None:
+    """Update the stored salt key hash to match the current LITELLM_SALT_KEY."""
+
+    salt_key = os.getenv("LITELLM_SALT_KEY")
+    if not salt_key:
+        raise RuntimeError("LITELLM_SALT_KEY environment variable is required")
+
+    salt_hash = hashlib.sha256(salt_key.encode()).hexdigest()
+
+    prisma = Prisma()
+    await prisma.connect()
+
+    try:
+        await prisma.litellm_metadatable.upsert(
+            where={"key": "salt_key_hash"},
+            data={
+                "create": {"key": "salt_key_hash", "value": salt_hash},
+                "update": {"value": salt_hash},
+            },
+        )
+        print("Salt key hash updated")  # noqa: T201
+    finally:
+        await prisma.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(update_salt_key_hash())
+

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -47,6 +47,32 @@ def _get_salt_key() -> str:
     return salt_key
 
 
+async def verify_and_store_salt_hash(prisma_client) -> None:
+    """Ensure the stored salt key hash matches the current salt key.
+
+    If no hash is stored, save the current hash. If hashes differ, raise an error
+    instructing the user to re-encrypt existing data or update the stored hash.
+    """
+
+    if prisma_client is None:
+        return
+
+    try:
+        current_hash = hashlib.sha256(_get_salt_key().encode()).hexdigest()
+        table = prisma_client.db.litellm_metadatable
+        existing = await table.find_first(where={"key": "salt_key_hash"})
+        if existing is None:
+            await table.create(data={"key": "salt_key_hash", "value": current_hash})
+            return
+        if existing.value != current_hash:
+            raise RuntimeError(
+                "Salt key mismatch detected. Re-encrypt existing secrets or "
+                "update stored hash via update_salt_key_hash script."
+            )
+    except Exception as e:
+        raise e
+
+
 def encrypt_value_helper(value: str, new_encryption_key: Optional[str] = None):
     signing_key = new_encryption_key or _get_salt_key()
     prefix = _salt_hash_prefix(signing_key)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -206,6 +206,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     _get_salt_key,
     decrypt_value_helper,
     encrypt_value_helper,
+    verify_and_store_salt_hash,
 )
 from litellm.proxy.common_utils.html_forms.ui_login import html_form
 from litellm.proxy.common_utils.http_parsing_utils import (
@@ -649,6 +650,9 @@ async def proxy_startup_event(app: FastAPI):
             proxy_logging_obj=proxy_logging_obj,
             user_api_key_cache=user_api_key_cache,
         )
+
+    if prisma_client is not None:
+        await verify_and_store_salt_hash(prisma_client)
 
     ProxyStartupEvent._initialize_startup_logging(
         llm_router=llm_router,

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -530,6 +530,14 @@ model LiteLLM_PromptTable {
   updated_at DateTime @updatedAt
 }
 
+model LiteLLM_MetadataTable {
+  metadata_id String @id @default(uuid())
+  key String @unique
+  value String
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+}
+
 model LiteLLM_HealthCheckTable {
   health_check_id String @id @default(uuid())
   model_name String

--- a/schema.prisma
+++ b/schema.prisma
@@ -530,6 +530,14 @@ model LiteLLM_PromptTable {
   updated_at DateTime @updatedAt
 }
 
+model LiteLLM_MetadataTable {
+  metadata_id String @id @default(uuid())
+  key String @unique
+  value String
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+}
+
 model LiteLLM_HealthCheckTable {
   health_check_id String @id @default(uuid())
   model_name String

--- a/tests/test_salt_key.py
+++ b/tests/test_salt_key.py
@@ -1,7 +1,14 @@
 import sys
 import types
+import os
+import importlib
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from litellm.proxy.common_utils import encrypt_decrypt_utils
+encrypt_decrypt_utils = importlib.reload(encrypt_decrypt_utils)
+import asyncio
+import hashlib
+import pytest
 
 
 def reset_cache(monkeypatch, master_key=None):
@@ -22,3 +29,44 @@ def test_get_salt_key_from_env(monkeypatch):
 def test_get_salt_key_from_master_key(monkeypatch):
     reset_cache(monkeypatch, master_key='mkey')
     assert encrypt_decrypt_utils._get_salt_key() == 'mkey'
+
+
+class DummyMetadataTable:
+    def __init__(self, value=None):
+        self.value = value
+
+    async def find_first(self, where):
+        if self.value is None:
+            return None
+        return types.SimpleNamespace(key=where["key"], value=self.value)
+
+    async def create(self, data):
+        self.value = data["value"]
+
+
+class DummyDB:
+    def __init__(self, value=None):
+        self.litellm_metadatable = DummyMetadataTable(value)
+
+
+class DummyPrisma:
+    def __init__(self, value=None):
+        self.db = DummyDB(value)
+
+
+def test_verify_and_store_salt_hash_creates(monkeypatch):
+    reset_cache(monkeypatch)
+    encrypt_decrypt_utils._cached_salt_key = "testkey"
+    client = DummyPrisma()
+    asyncio.run(encrypt_decrypt_utils.verify_and_store_salt_hash(client))
+    expected = hashlib.sha256(b"testkey").hexdigest()
+    assert client.db.litellm_metadatable.value == expected
+
+
+def test_verify_and_store_salt_hash_mismatch(monkeypatch):
+    reset_cache(monkeypatch)
+    encrypt_decrypt_utils._cached_salt_key = "first"
+    existing = hashlib.sha256(b"second").hexdigest()
+    client = DummyPrisma(existing)
+    with pytest.raises(RuntimeError):
+        asyncio.run(encrypt_decrypt_utils.verify_and_store_salt_hash(client))


### PR DESCRIPTION
## Summary
- verify salt key against stored DB hash on startup
- add metadata table for salt key hash
- provide script to update stored hash after key rotation

## Testing
- `pytest tests/test_salt_key.py -q`
- `ruff check litellm/proxy/common_utils/encrypt_decrypt_utils.py litellm/proxy/proxy_server.py tests/test_salt_key.py db_scripts/update_salt_key_hash.py`


------
https://chatgpt.com/codex/tasks/task_e_68b93c28579c8321aba35eb1cd9d2b0e