### PR TITLE
Use Ameritas branding for proxy Swagger docs

### DIFF
--- a/litellm/proxy/openapi.json
+++ b/litellm/proxy/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
-    "title": "LiteLLM API",
-    "description": "API for LiteLLM"
+    "title": "Ameritas LLM API",
+    "description": "API for Ameritas LLM"
   },
   "paths": {
    "/chat/completions": {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -203,9 +203,9 @@ from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_pr
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    _get_salt_key,
     decrypt_value_helper,
     encrypt_value_helper,
-    _get_salt_key,
 )
 from litellm.proxy.common_utils.html_forms.ui_login import html_form
 from litellm.proxy.common_utils.http_parsing_utils import (
@@ -516,25 +516,13 @@ else:
 
 ui_link = f"{server_root_path}/ui/"
 model_hub_link = f"{server_root_path}/ui/model_hub_table"
-ui_message = (
-    f"👉 [```LiteLLM Admin Panel on /ui```]({ui_link}). Create, Edit Keys with SSO"
-)
-ui_message += "\n\n💸 [```LiteLLM Model Cost Map```](https://models.litellm.ai/)."
+ui_message = "💸 [```LiteLLM Model Cost Map```](https://models.litellm.ai/)."
 
-ui_message += f"\n\n🔎 [```LiteLLM Model Hub```]({model_hub_link}). See available models on the proxy. [**Docs**](https://docs.litellm.ai/docs/proxy/model_hub)"
-
-custom_swagger_message = "[**Customize Swagger Docs**](https://docs.litellm.ai/docs/proxy/enterprise#swagger-docs---custom-routes--branding)"
+ui_message += f"\n\n🔎 [```Ameritas Model Hub```]({model_hub_link}). See available models on the proxy. [**Docs**](https://docs.litellm.ai/docs/proxy/model_hub)"
 
 ### CUSTOM BRANDING [ENTERPRISE FEATURE] ###
-_title = os.getenv("DOCS_TITLE", "LiteLLM API") if premium_user else "LiteLLM API"
-_description = (
-    os.getenv(
-        "DOCS_DESCRIPTION",
-        f"Enterprise Edition \n\nProxy Server to call 100+ LLMs in the OpenAI format. {custom_swagger_message}\n\n{ui_message}",
-    )
-    if premium_user
-    else f"Proxy Server to call 100+ LLMs in the OpenAI format. {custom_swagger_message}\n\n{ui_message}"
-)
+_title = os.getenv("DOCS_TITLE", "Ameritas LLM API") if premium_user else "Ameritas LLM API"
+_description = os.getenv("DOCS_DESCRIPTION", ui_message)
 
 
 def cleanup_router_config_variables():

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -46,7 +46,7 @@ interface PublicModelHubProps {
 
 const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
   const [modelHubData, setModelHubData] = useState<ModelGroupInfo[] | null>(null);
-  const [pageTitle, setPageTitle] = useState<string>("Ameritas LiteLLM Gateway");
+  const [pageTitle, setPageTitle] = useState<string>("Ameritas LLM API");
   const [customDocsDescription, setCustomDocsDescription] = useState<string | null>(null);
   const [litellmVersion, setLitellmVersion] = useState<string>("");
   const [usefulLinks, setUsefulLinks] = useState<Record<string, string>>({});
@@ -499,7 +499,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
         {/* About Section */}
           <Card className="mb-10 p-8 bg-white border border-gray-200 rounded-lg shadow-sm">
             <Title className="text-2xl font-semibold mb-6 text-gray-900">About</Title>
-            <p className="text-gray-700 mb-6 text-base leading-relaxed">{customDocsDescription ? customDocsDescription : "Proxy Server to call 100+ LLMs in the OpenAI format."}</p>
+            <p className="text-gray-700 mb-6 text-base leading-relaxed">{customDocsDescription || ""}</p>
             <div className="flex items-center space-x-3 text-sm text-gray-600">
               <span className="flex items-center">
                 <span className="w-4 h-4 mr-2">🔧</span>


### PR DESCRIPTION
## Summary
- use `ui_message` or `DOCS_DESCRIPTION` env var for Swagger docs description
- default docs title to "Ameritas LLM API"
- drop "Proxy Server to call 100+ LLMs" tagline from public Model Hub component
- remove admin panel link from Swagger description
- rename LiteLLM Model Hub link to Ameritas Model Hub

## Testing
- `pre-commit run --files litellm/proxy/proxy_server.py litellm/proxy/openapi.json ui/litellm-dashboard/src/components/public_model_hub.tsx`
- `pytest tests/proxy` *(fails: file or directory not found)*
- `pytest tests/test_proxy_server_litellm_params.py`
- `python -c "import litellm.proxy.proxy_server as ps"` *(fails: ModuleNotFoundError: No module named 'mcp.client.streamable_http')*


------
https://chatgpt.com/codex/tasks/task_e_68b938dd5a288321b1d4ec9da1a98ce4