### PR TITLE
Handle disabled cache ping response

### DIFF
--- a/docs/my-website/docs/proxy/caching.md
+++ b/docs/my-website/docs/proxy/caching.md
@@ -20,7 +20,26 @@ Cache LLM Responses. LiteLLM's caching system stores and reuses LLM responses to
 - Redis Cache 
 - Qdrant Semantic Cache
 - Redis Semantic Cache
-- s3 Bucket Cache 
+- s3 Bucket Cache
+
+### Checking Cache Status
+
+Use the `/cache/ping` endpoint to verify whether caching is configured. When caching is not set up, the proxy responds with:
+
+```json
+{"status": "disabled"}
+```
+
+Enable caching by adding it to your `proxy_server_config.yaml`:
+
+```yaml
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis
+    host: localhost
+    port: 6379
+```
 
 ## Quick Start
 <Tabs>

--- a/litellm/proxy/caching_routes.py
+++ b/litellm/proxy/caching_routes.py
@@ -62,8 +62,10 @@ async def cache_ping():
     cleaned_cache_params: Dict[str, Any] = {}
     try:
         if litellm.cache is None:
-            raise HTTPException(
-                status_code=503, detail="Cache not initialized. litellm.cache is None"
+            return CachePingResponse(
+                status="disabled",
+                cache_type="none",
+                set_cache_response="Caching is disabled. Enable by setting 'litellm_settings.cache: true' and appropriate cache_params in proxy_server_config.yaml.",
             )
         litellm_cache_params = masker.mask_dict(vars(litellm.cache))
         # remove field that might reference itself

--- a/tests/test_cache_ping.py
+++ b/tests/test_cache_ping.py
@@ -1,0 +1,16 @@
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import litellm
+from litellm.proxy.caching_routes import cache_ping
+
+
+def test_cache_ping_disabled(monkeypatch):
+    monkeypatch.setattr(litellm, "cache", None)
+    response = asyncio.run(cache_ping())
+    assert response.status == "disabled"
+    assert response.cache_type == "none"
+    assert "enable" in (response.set_cache_response or "").lower()


### PR DESCRIPTION
## Summary
- Return HTTP 200 `status="disabled"` from `/cache/ping` when caching is not configured, with guidance on enabling it
- Document cache ping "disabled" status and show how to enable caching in `proxy_server_config.yaml`
- Add test covering cache ping disabled behavior

## Testing
- `pytest tests/test_cache_ping.py -q`
- `ruff check litellm/proxy/caching_routes.py tests/test_cache_ping.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94d962b808321811046dbde32547a