### PR TITLE
feat: add cache configuration ui

### DIFF
--- a/docs/my-website/docs/proxy/caching.md
+++ b/docs/my-website/docs/proxy/caching.md
@@ -41,6 +41,8 @@ litellm_settings:
     port: 6379
 ```
 
+Caching can also be enabled and configured through the admin UI under **Cache Settings**.
+
 ## Quick Start
 <Tabs>
 

--- a/ui/litellm-dashboard/src/components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/cache_dashboard.tsx
@@ -42,6 +42,7 @@ import {
 
 // Import the new component
 import { CacheHealthTab } from "./cache_health";
+import CacheSettings from "./cache_settings";
 
 const formatDateWithoutTZ = (date: Date | undefined) => {
     if (!date) return undefined;
@@ -301,6 +302,7 @@ const runCachingHealthCheck = async () => {
             <Tab>
               <pre>Cache Health</pre>
             </Tab>
+            <Tab>Cache Settings</Tab>
           </div>
 
           <div className="flex items-center space-x-2">
@@ -316,7 +318,7 @@ const runCachingHealthCheck = async () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-          <Card>      
+          <Card>
       <Grid numItems={3} className="gap-4 mt-4">
         <Col>
           <MultiSelect
@@ -421,11 +423,14 @@ const runCachingHealthCheck = async () => {
       </Card>
           </TabPanel>
           <TabPanel>
-            <CacheHealthTab 
+            <CacheHealthTab
               accessToken={accessToken}
               healthCheckResponse={healthCheckResponse}
               runCachingHealthCheck={runCachingHealthCheck}
             />
+          </TabPanel>
+          <TabPanel>
+            <CacheSettings accessToken={accessToken} />
           </TabPanel>
         </TabPanels>
       </TabGroup>

--- a/ui/litellm-dashboard/src/components/cache_settings.tsx
+++ b/ui/litellm-dashboard/src/components/cache_settings.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+import {
+  Card,
+  Title,
+  Text,
+  Switch,
+  Select,
+  SelectItem,
+  TextInput,
+  Button,
+} from "@tremor/react";
+import {
+  getCacheConfig,
+  updateCacheConfig,
+  cachingHealthCheckCall,
+} from "./networking";
+import NotificationsManager from "./molecules/notifications_manager";
+
+interface CacheSettingsProps {
+  accessToken: string | null;
+}
+
+const cacheTypeOptions = [
+  "redis",
+  "disk",
+  "in_memory",
+  "s3",
+  "qdrant",
+  "redis_semantic",
+];
+
+const cacheTypeParams: Record<string, { key: string; label: string }[]> = {
+  redis: [
+    { key: "host", label: "Host" },
+    { key: "port", label: "Port" },
+  ],
+  qdrant: [
+    { key: "host", label: "Host" },
+    { key: "port", label: "Port" },
+  ],
+  redis_semantic: [
+    { key: "host", label: "Host" },
+    { key: "port", label: "Port" },
+  ],
+  s3: [
+    { key: "bucket", label: "Bucket" },
+    { key: "region", label: "Region" },
+  ],
+  disk: [{ key: "cache_dir", label: "Cache Directory" }],
+  in_memory: [],
+};
+
+export const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
+  const [cacheEnabled, setCacheEnabled] = useState(false);
+  const [cacheType, setCacheType] = useState<string>("redis");
+  const [params, setParams] = useState<Record<string, any>>({});
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    getCacheConfig(accessToken)
+      .then((data) => {
+        if (data?.cache !== undefined) {
+          setCacheEnabled(data.cache);
+        }
+        const cp = data?.cache_params || {};
+        setCacheType(cp.type || "redis");
+        setParams(cp);
+      })
+      .catch(() => {});
+  }, [accessToken]);
+
+  const handleParamChange = (key: string, value: string) => {
+    setParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = async () => {
+    if (!accessToken) return;
+    setSaving(true);
+    try {
+      await updateCacheConfig(accessToken, "cache", cacheEnabled);
+      const paramsWithType = { ...params, type: cacheType };
+      await updateCacheConfig(accessToken, "cache_params", paramsWithType);
+      const ping = await cachingHealthCheckCall(accessToken);
+      if (ping?.ping_response || ping?.status === "ok") {
+        NotificationsManager.success("Cache settings updated successfully");
+      } else {
+        NotificationsManager.fromBackend("Cache ping failed");
+      }
+    } catch (e) {
+      NotificationsManager.fromBackend(e as any);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Title>Cache Settings</Title>
+      <div className="space-y-4 mt-4">
+        <div className="flex items-center gap-2">
+          <Text>Enable Caching</Text>
+          <Switch checked={cacheEnabled} onChange={setCacheEnabled} />
+        </div>
+        <div>
+          <Text className="mb-1">Cache Type</Text>
+          <Select value={cacheType} onValueChange={(value) => setCacheType(value)}>
+            {cacheTypeOptions.map((option) => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </Select>
+        </div>
+        {cacheTypeParams[cacheType]?.map((field) => (
+          <div key={field.key}>
+            <Text className="mb-1">{field.label}</Text>
+            <TextInput
+              value={params[field.key] ?? ""}
+              onChange={(e) => handleParamChange(field.key, e.target.value)}
+            />
+          </div>
+        ))}
+        <Button onClick={handleSave} loading={saving}>
+          Save
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default CacheSettings;
+

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5104,6 +5104,46 @@ export const cachingHealthCheckCall = async (accessToken: String) => {
   }
 };
 
+export const getCacheConfig = async (accessToken: String) => {
+  try {
+    const cache = await getConfigFieldSetting(
+      accessToken,
+      "cache",
+      "litellm_settings"
+    );
+    const cacheParams = await getConfigFieldSetting(
+      accessToken,
+      "cache_params",
+      "litellm_settings"
+    );
+    return {
+      cache: cache?.field_value,
+      cache_params: cacheParams?.field_value,
+    };
+  } catch (error) {
+    console.error("Failed to fetch cache config:", error);
+    throw error;
+  }
+};
+
+export const updateCacheConfig = async (
+  accessToken: String,
+  fieldName: "cache" | "cache_params",
+  fieldValue: any
+) => {
+  try {
+    return await updateConfigFieldSetting(
+      accessToken,
+      fieldName,
+      fieldValue,
+      "litellm_settings"
+    );
+  } catch (error) {
+    console.error("Failed to update cache config:", error);
+    throw error;
+  }
+};
+
 export const healthCheckHistoryCall = async (
   accessToken: String,
   model?: string,


### PR DESCRIPTION
## Summary
- add networking helpers for cache config
- introduce CacheSettings component with toggle and param inputs
- document enabling cache via admin UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b94fa95adc8321a29f0630f160295c