### PR TITLE
Restrict cache setting input types

### DIFF
--- a/ui/litellm-dashboard/src/components/cache_settings.tsx
+++ b/ui/litellm-dashboard/src/components/cache_settings.tsx
@@ -32,7 +32,7 @@ const cacheTypeOptions = [
 interface CacheParamField {
   key: string;
   label: string;
-  type?: string;
+  type?: 'text' | 'url' | 'email' | 'password';
   placeholder?: string;
 }
 


### PR DESCRIPTION
## Summary
- tighten cache param field typing to limited HTML input types
- ensure cache type parameters only use allowed input types

## Testing
- `pre-commit run --files ui/litellm-dashboard/src/components/cache_settings.tsx`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b95bc83234832187a0f985b1658eaa