### PR TITLE
Guard metadata table lookup in salt key verification

### DIFF
--- a/db_scripts/update_salt_key_hash.py
+++ b/db_scripts/update_salt_key_hash.py
@@ -18,7 +18,12 @@ async def update_salt_key_hash() -> None:
     await prisma.connect()
 
     try:
-        await prisma.litellm_metadatable.upsert(
+        table = getattr(prisma, "litellm_metadatatable", None)
+        if table is None:
+            print("LiteLLM_MetadataTable not found on Prisma client. Skipping update.")  # noqa: T201
+            return
+
+        await table.upsert(
             where={"key": "salt_key_hash"},
             data={
                 "create": {"key": "salt_key_hash", "value": salt_hash},

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -59,7 +59,13 @@ async def verify_and_store_salt_hash(prisma_client) -> None:
 
     try:
         current_hash = hashlib.sha256(_get_salt_key().encode()).hexdigest()
-        table = prisma_client.db.litellm_metadatable
+        table = getattr(prisma_client.db, "litellm_metadatatable", None)
+        if table is None:
+            verbose_proxy_logger.warning(
+                "LiteLLM_MetadataTable not found on Prisma client. Skipping salt hash verification."
+            )
+            return
+
         existing = await table.find_first(where={"key": "salt_key_hash"})
         if existing is None:
             await table.create(data={"key": "salt_key_hash", "value": current_hash})

--- a/tests/test_salt_key.py
+++ b/tests/test_salt_key.py
@@ -46,7 +46,7 @@ class DummyMetadataTable:
 
 class DummyDB:
     def __init__(self, value=None):
-        self.litellm_metadatable = DummyMetadataTable(value)
+        self.litellm_metadatatable = DummyMetadataTable(value)
 
 
 class DummyPrisma:
@@ -60,7 +60,7 @@ def test_verify_and_store_salt_hash_creates(monkeypatch):
     client = DummyPrisma()
     asyncio.run(encrypt_decrypt_utils.verify_and_store_salt_hash(client))
     expected = hashlib.sha256(b"testkey").hexdigest()
-    assert client.db.litellm_metadatable.value == expected
+    assert client.db.litellm_metadatatable.value == expected
 
 
 def test_verify_and_store_salt_hash_mismatch(monkeypatch):


### PR DESCRIPTION
## Summary
- guard salt key verification against missing Prisma table
- align metadata table name and update script/tests

## Testing
- `ruff check litellm/proxy/common_utils/encrypt_decrypt_utils.py db_scripts/update_salt_key_hash.py tests/test_salt_key.py`
- `pytest tests/test_salt_key.py`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*
- `LITELLM_SALT_KEY=testkey DATABASE_URL=postgresql://user:pass@localhost:5432/postgres python -m litellm.proxy.proxy_server` *(fails: ModuleNotFoundError: No module named 'mcp.client.streamable_http')*

------
https://chatgpt.com/codex/tasks/task_e_68b969ba0648832186dd6f5dc12fbe2e