### PR TITLE
Handle Bedrock guardrail errors

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -340,24 +340,49 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             data=prepared_request.body,  # type: ignore
             headers=prepared_request.headers,  # type: ignore
         )
+
+        try:
+            response_json = response.json()
+        except Exception:
+            response_json = {}
+
+        guardrail_status: Literal["success", "failure"] = (
+            "success" if response.status_code == 200 else "failure"
+        )
+
+        end_time = datetime.now()
+        guardrail_json_response = (
+            _redact_pii_matches(response_json)
+            if isinstance(response_json, dict)
+            else {"raw_response": getattr(response, "text", "")}
+        )
+
         #########################################################
         # Add guardrail information to request trace
         #########################################################
         self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_json_response=response.json(),
+            guardrail_json_response=guardrail_json_response,
             request_data=request_data or {},
-            guardrail_status=self._get_bedrock_guardrail_response_status(response=response),
+            guardrail_status=guardrail_status,
             start_time=start_time.timestamp(),
-            end_time=datetime.now().timestamp(),
-            duration=(datetime.now() - start_time).total_seconds(),
+            end_time=end_time.timestamp(),
+            duration=(end_time - start_time).total_seconds(),
         )
         #########################################################
         if response.status_code == 200:
             # check if the response was flagged
-            _json_response = response.json()
-            redacted_response = _redact_pii_matches(_json_response)
-            verbose_proxy_logger.debug("Bedrock AI response : %s", redacted_response)
-            bedrock_guardrail_response = BedrockGuardrailResponse(**_json_response)
+            if not isinstance(response_json, dict):
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "error": "Unexpected Bedrock guardrail response format.",
+                        "aws_response": getattr(response, "text", ""),
+                    },
+                )
+            verbose_proxy_logger.debug(
+                "Bedrock AI response : %s", guardrail_json_response
+            )
+            bedrock_guardrail_response = BedrockGuardrailResponse(**response_json)
             if self._should_raise_guardrail_blocked_exception(
                 bedrock_guardrail_response
             ):
@@ -369,6 +394,46 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 "Bedrock AI: error in response. Status code: %s, response: %s",
                 response.status_code,
                 response.text,
+            )
+            aws_error_message: str = ""
+            if isinstance(response_json, dict):
+                aws_error_message = (
+                    response_json.get("message")
+                    or response_json.get("Message")
+                    or response_json.get("errorMessage")
+                    or response_json.get("ErrorMessage")
+                    or response_json.get("detail")
+                    or ""
+                )
+            if not aws_error_message:
+                aws_error_message = getattr(response, "text", "")
+
+            if response.status_code == 403:
+                base_error_message = (
+                    "AWS Bedrock Guardrails request failed with status 403 (Forbidden). "
+                    "Verify that the IAM principal calling the guardrail has the `bedrock:ApplyGuardrail` "
+                    "and `bedrock:ApplyGuardrailAction` IAM permissions."
+                )
+            else:
+                base_error_message = (
+                    f"AWS Bedrock Guardrails request failed with status {response.status_code}."
+                )
+
+            if aws_error_message:
+                base_error_message = (
+                    f"{base_error_message} AWS response message: {aws_error_message}"
+                )
+
+            aws_response_detail: Union[dict, str] = (
+                response_json if isinstance(response_json, dict) else aws_error_message
+            )
+
+            raise HTTPException(
+                status_code=response.status_code,
+                detail={
+                    "error": base_error_message,
+                    "aws_response": aws_response_detail,
+                },
             )
 
         return bedrock_guardrail_response

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -364,15 +364,18 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 },
             ) from exc
 
-        guardrail_status: Literal["success", "failure"] = (
-            "success" if response.status_code == 200 else "failure"
-        )
-
         end_time = datetime.now()
+        raw_response_text = getattr(response, "text", "")
+        payload_is_valid = isinstance(response_json, dict)
+
         guardrail_json_response = (
             _redact_pii_matches(response_json)
-            if isinstance(response_json, dict)
-            else {"raw_response": getattr(response, "text", "")}
+            if payload_is_valid
+            else {"raw_response": raw_response_text}
+        )
+
+        guardrail_status: Literal["success", "failure"] = (
+            "success" if response.status_code == 200 and payload_is_valid else "failure"
         )
 
         #########################################################
@@ -389,12 +392,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         #########################################################
         if response.status_code == 200:
             # check if the response was flagged
-            if not isinstance(response_json, dict):
+            if not payload_is_valid:
                 raise HTTPException(
                     status_code=500,
                     detail={
                         "error": "Unexpected Bedrock guardrail response format.",
-                        "aws_response": getattr(response, "text", ""),
+                        "aws_response": raw_response_text,
                     },
                 )
             verbose_proxy_logger.debug(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -343,8 +343,26 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         try:
             response_json = response.json()
-        except Exception:
-            response_json = {}
+        except (json.JSONDecodeError, ValueError) as exc:
+            end_time = datetime.now()
+            guardrail_status: Literal["success", "failure"] = "failure"
+            raw_response_text = getattr(response, "text", "")
+            guardrail_json_response = {"raw_response": raw_response_text}
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_json_response=guardrail_json_response,
+                request_data=request_data or {},
+                guardrail_status=guardrail_status,
+                start_time=start_time.timestamp(),
+                end_time=end_time.timestamp(),
+                duration=(end_time - start_time).total_seconds(),
+            )
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "Failed to decode AWS Bedrock guardrail response JSON.",
+                    "aws_response": raw_response_text,
+                },
+            ) from exc
 
         guardrail_status: Literal["success", "failure"] = (
             "success" if response.status_code == 200 else "failure"

--- a/tests/proxy/guardrails/test_bedrock_guardrail.py
+++ b/tests/proxy/guardrails/test_bedrock_guardrail.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockGuardrail
+
+
+class MockResponse:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def patched_guardrail(monkeypatch):
+    monkeypatch.setattr(
+        BedrockGuardrail,
+        "_load_credentials",
+        lambda self: (None, "us-east-1"),
+    )
+
+    def _fake_prepare(
+        self,
+        credentials,
+        data,
+        optional_params,
+        aws_region_name,
+        api_key=None,
+        extra_headers=None,
+    ):
+        return SimpleNamespace(url="https://example.com", headers={}, body=b"{}")
+
+    monkeypatch.setattr(BedrockGuardrail, "_prepare_request", _fake_prepare)
+
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="guardrail-id",
+        guardrailVersion="1",
+    )
+    return guardrail
+
+
+def test_make_bedrock_api_request_raises_forbidden(patched_guardrail):
+    guardrail = patched_guardrail
+    logging_mock = MagicMock()
+    guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
+
+    response_payload = {"message": "Access denied"}
+    guardrail.async_handler.post = AsyncMock(return_value=MockResponse(403, response_payload))
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[],
+                request_data={},
+            )
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "bedrock:ApplyGuardrail" in exc_info.value.detail["error"]
+    logging_mock.assert_called_once()
+    assert logging_mock.call_args.kwargs["guardrail_status"] == "failure"
+
+
+def test_make_bedrock_api_request_raises_server_error(patched_guardrail):
+    guardrail = patched_guardrail
+    logging_mock = MagicMock()
+    guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
+
+    response_payload = {"message": "Internal error"}
+    guardrail.async_handler.post = AsyncMock(return_value=MockResponse(500, response_payload))
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[],
+                request_data={},
+            )
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "status 500" in exc_info.value.detail["error"]
+    assert exc_info.value.detail["aws_response"] == response_payload
+    logging_mock.assert_called_once()
+    assert logging_mock.call_args.kwargs["guardrail_status"] == "failure"

--- a/tests/proxy/guardrails/test_bedrock_guardrail.py
+++ b/tests/proxy/guardrails/test_bedrock_guardrail.py
@@ -3,6 +3,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,12 +15,22 @@ from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockG
 
 
 class MockResponse:
-    def __init__(self, status_code: int, payload):
+    def __init__(
+        self,
+        status_code: int,
+        payload,
+        *,
+        text: Optional[str] = None,
+        json_exc: Optional[Exception] = None,
+    ):
         self.status_code = status_code
         self._payload = payload
-        self.text = json.dumps(payload)
+        self._json_exc = json_exc
+        self.text = text if text is not None else json.dumps(payload)
 
     def json(self):
+        if self._json_exc is not None:
+            raise self._json_exc
         return self._payload
 
 
@@ -94,5 +105,35 @@ def test_make_bedrock_api_request_raises_server_error(patched_guardrail):
     assert exc_info.value.status_code == 500
     assert "status 500" in exc_info.value.detail["error"]
     assert exc_info.value.detail["aws_response"] == response_payload
+    logging_mock.assert_called_once()
+    assert logging_mock.call_args.kwargs["guardrail_status"] == "failure"
+
+
+def test_make_bedrock_api_request_raises_on_json_decode_failure(patched_guardrail):
+    guardrail = patched_guardrail
+    logging_mock = MagicMock()
+    guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
+
+    json_error = json.JSONDecodeError("Expecting value", "", 0)
+    mock_response = MockResponse(
+        200,
+        payload={},
+        text="<html>Service unavailable</html>",
+        json_exc=json_error,
+    )
+    guardrail.async_handler.post = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[],
+                request_data={},
+            )
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "Failed to decode" in exc_info.value.detail["error"]
+    assert exc_info.value.detail["aws_response"] == mock_response.text
     logging_mock.assert_called_once()
     assert logging_mock.call_args.kwargs["guardrail_status"] == "failure"


### PR DESCRIPTION
## Summary
- ensure Bedrock guardrail requests log success or failure status and parse JSON responses before raising errors
- raise detailed HTTPExceptions for non-200 responses, including guidance for missing IAM permissions on 403 errors
- add pytest coverage that mocks Bedrock guardrail HTTP responses to verify error handling behaviour

## Testing
- pytest tests/proxy/guardrails/test_bedrock_guardrail.py

------
https://chatgpt.com/codex/tasks/task_e_68d33cfdd5fc8321a38e7a61577d21eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Clearer Bedrock guardrail error messages, inclusion of AWS response details (redacted when appropriate), and consistent guardrail status, end time, and duration in traces.

* Bug Fixes
  * Robust handling of non-JSON, invalid, non-200, and 403 responses with validated payloads and user-friendly error guidance to prevent crashes.

* Tests
  * Added tests covering 403, 500, and JSON-decode failure paths and verifying logging/trace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->