### PR TITLE
Ensure Bedrock guardrail configuration validates required data

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -32,7 +32,7 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.guardrails import BedrockGuardrailConfigModel, GuardrailEventHooks
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockContentItem,
@@ -105,6 +105,50 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         disable_exception_on_block: Optional[bool] = False,
         **kwargs,
     ):
+        def _is_missing(value: Optional[str]) -> bool:
+            if value is None:
+                return True
+            if isinstance(value, str):
+                return value.strip() == ""
+            return False
+
+        aws_region_name = kwargs.get("aws_region_name")
+        missing_fields = []
+        if _is_missing(guardrailIdentifier):
+            missing_fields.append("guardrailIdentifier")
+        if _is_missing(guardrailVersion):
+            missing_fields.append("guardrailVersion")
+        if _is_missing(aws_region_name):
+            missing_fields.append("aws_region_name")
+
+        if missing_fields:
+            raise ValueError(
+                "Bedrock guardrail misconfiguration: missing required field(s): "
+                + ", ".join(missing_fields)
+            )
+
+        config_kwargs = {
+            "guardrailIdentifier": guardrailIdentifier,
+            "guardrailVersion": guardrailVersion,
+            "aws_region_name": aws_region_name,
+            "disable_exception_on_block": disable_exception_on_block,
+        }
+        for key in (
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_session_name",
+            "aws_profile_name",
+            "aws_role_name",
+            "aws_web_identity_token",
+            "aws_sts_endpoint",
+            "aws_bedrock_runtime_endpoint",
+        ):
+            if key in kwargs:
+                config_kwargs[key] = kwargs[key]
+
+        BedrockGuardrailConfigModel(**config_kwargs)
+
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -1,8 +1,9 @@
+import os
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Required, TypedDict
 
 from litellm.types.proxy.guardrails.guardrail_hooks.openai.openai_moderation import (
@@ -268,19 +269,20 @@ class PresidioConfigModel(PresidioPresidioConfigModelUserInterface):
 class BedrockGuardrailConfigModel(BaseModel):
     """Configuration parameters for the AWS Bedrock guardrail"""
 
-    guardrailIdentifier: Optional[str] = Field(
-        default=None, description="The ID of your guardrail on Bedrock"
+    guardrailIdentifier: str = Field(
+        ..., min_length=1, description="The ID of your guardrail on Bedrock"
     )
-    guardrailVersion: Optional[str] = Field(
-        default=None,
+    guardrailVersion: str = Field(
+        ...,
+        min_length=1,
         description="The version of your Bedrock guardrail (e.g., DRAFT or version number)",
     )
     disable_exception_on_block: Optional[bool] = Field(
         default=False,
         description="If True, will not raise an exception when the guardrail is blocked. Useful for OpenWebUI where exceptions can end the chat flow.",
     )
-    aws_region_name: Optional[str] = Field(
-        default=None, description="AWS region where your guardrail is deployed"
+    aws_region_name: str = Field(
+        ..., min_length=1, description="AWS region where your guardrail is deployed"
     )
     aws_access_key_id: Optional[str] = Field(
         default=None, description="AWS access key ID for authentication"
@@ -311,6 +313,69 @@ class BedrockGuardrailConfigModel(BaseModel):
     )
 
 
+    @model_validator(mode="after")
+    def _validate_authentication(self) -> "BedrockGuardrailConfigModel":
+        """Ensure that at least one AWS authentication mechanism is configured."""
+
+        if (
+            not self.guardrailIdentifier
+            or not self.guardrailVersion
+            or not self.aws_region_name
+        ):
+            return self
+
+        errors: List[str] = []
+
+        has_access_keys = bool(self.aws_access_key_id and self.aws_secret_access_key)
+        if self.aws_access_key_id and not self.aws_secret_access_key:
+            errors.append(
+                "aws_secret_access_key must be provided when aws_access_key_id is set."
+            )
+        if self.aws_secret_access_key and not self.aws_access_key_id:
+            errors.append(
+                "aws_access_key_id must be provided when aws_secret_access_key is set."
+            )
+        if self.aws_session_token and not has_access_keys:
+            errors.append(
+                "aws_session_token requires both aws_access_key_id and aws_secret_access_key."
+            )
+
+        if self.aws_web_identity_token and (
+            not self.aws_role_name or not self.aws_session_name
+        ):
+            errors.append(
+                "aws_role_name and aws_session_name are required when using aws_web_identity_token."
+            )
+
+        if errors:
+            raise ValueError(" ".join(errors))
+
+        has_profile = bool(self.aws_profile_name)
+        has_role = bool(self.aws_role_name)
+        has_web_identity = bool(
+            self.aws_web_identity_token
+            and self.aws_role_name
+            and self.aws_session_name
+        )
+        has_authentication = any(
+            [
+                has_access_keys,
+                has_profile,
+                has_role,
+                has_web_identity,
+                bool(os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")),
+                bool(os.getenv("AWS_PROFILE") or os.getenv("AWS_DEFAULT_PROFILE")),
+                bool(os.getenv("AWS_ROLE_ARN")),
+                bool(os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE")),
+            ]
+        )
+
+        if not has_authentication:
+            raise ValueError(
+                "Bedrock guardrail configuration requires AWS credentials. Provide access keys, an AWS profile, an assumable role, a web identity token, or configure the equivalent environment variables."
+            )
+
+        return self
 
 class LakeraV2GuardrailConfigModel(BaseModel):
     """Configuration parameters for the Lakera AI v2 guardrail"""
@@ -451,6 +516,21 @@ class LitellmParams(
     mode: Union[str, List[str], Mode] = Field(
         description="When to apply the guardrail (pre_call, post_call, during_call, logging_only)"
     )
+    guardrailIdentifier: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="The ID of your guardrail on Bedrock",
+    )
+    guardrailVersion: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="The version of your Bedrock guardrail (e.g., DRAFT or version number)",
+    )
+    aws_region_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="AWS region where your guardrail is deployed",
+    )
 
     def __init__(self, **kwargs):
         default_on = kwargs.pop("default_on", None)
@@ -459,6 +539,26 @@ class LitellmParams(
         else:
             kwargs["default_on"] = False
         super().__init__(**kwargs)
+
+    @model_validator(mode="after")
+    def _validate_bedrock_requirements(self) -> "LitellmParams":
+        guardrail_type = getattr(self, "guardrail", None)
+        if guardrail_type == SupportedGuardrailIntegrations.BEDROCK.value:
+            missing_fields = [
+                field_name
+                for field_name in (
+                    "guardrailIdentifier",
+                    "guardrailVersion",
+                    "aws_region_name",
+                )
+                if not getattr(self, field_name, None)
+            ]
+            if missing_fields:
+                raise ValueError(
+                    "Bedrock guardrail configuration requires the following fields: "
+                    + ", ".join(missing_fields)
+                )
+        return self
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator

--- a/tests/proxy/guardrails/test_bedrock_guardrail.py
+++ b/tests/proxy/guardrails/test_bedrock_guardrail.py
@@ -36,6 +36,9 @@ class MockResponse:
 
 @pytest.fixture
 def patched_guardrail(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+
     monkeypatch.setattr(
         BedrockGuardrail,
         "_load_credentials",
@@ -58,8 +61,19 @@ def patched_guardrail(monkeypatch):
     guardrail = BedrockGuardrail(
         guardrailIdentifier="guardrail-id",
         guardrailVersion="1",
+        aws_region_name="us-west-2",
     )
     return guardrail
+
+
+def test_bedrock_guardrail_missing_required_fields(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+
+    with pytest.raises(ValueError) as exc_info:
+        BedrockGuardrail(guardrailVersion="1", aws_region_name="us-west-2")
+
+    assert "guardrailIdentifier" in str(exc_info.value)
 
 
 def test_make_bedrock_api_request_raises_forbidden(patched_guardrail):


### PR DESCRIPTION
## Summary
- require Bedrock guardrail identifier, version, and region in the shared config model and ensure at least one AWS auth path is configured
- fail fast in the BedrockGuardrail initializer when required metadata is missing by reusing the config validation
- update the Bedrock guardrail tests to set AWS env vars, require the region parameter, and cover the new validation error

## Testing
- pytest tests/proxy/guardrails

------
https://chatgpt.com/codex/tasks/task_e_68d354b872a08321bd3b54a99510eb73