### PR TITLE
docs: document bedrock guardrail permissions

### DIFF
--- a/docs/my-website/docs/apply_guardrail.md
+++ b/docs/my-website/docs/apply_guardrail.md
@@ -5,6 +5,9 @@ import TabItem from '@theme/TabItem';
 
 Use this endpoint to directly call a guardrail configured on your LiteLLM instance. This is useful when you have services that need to directly call a guardrail. 
 
+:::note Bedrock guardrails
+When the guardrail is backed by Amazon Bedrock, ensure the IAM role or user has permission to call `bedrock:ApplyGuardrail`, `bedrock:GetGuardrail`, and `bedrock:ListGuardrails`, and that `aws_region_name` matches the region in which the guardrail exists. See the [Bedrock guardrail permissions guide](proxy/guardrails/bedrock#permissions-and-troubleshooting) for more details.
+:::
 
 ## Usage
 ---

--- a/docs/my-website/docs/proxy/guardrails/bedrock.md
+++ b/docs/my-website/docs/proxy/guardrails/bedrock.md
@@ -42,7 +42,7 @@ guardrails:
 litellm --config config.yaml --detailed_debug
 ```
 
-### 3. Test request 
+### 3. Test request
 
 **[Langchain, OpenAI SDK Usage Examples](../proxy/user_keys#request-format)**
 
@@ -136,6 +136,19 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 
 </Tabs>
+
+## Permissions and Troubleshooting
+
+To successfully call Bedrock guardrails through LiteLLM, the AWS identity specified by `aws_role_name` (or the process's defaul
+t credentials) must be able to perform the following IAM actions on the guardrail resource:
+
+- `bedrock:ApplyGuardrail` – required to run the guardrail during a request
+- `bedrock:GetGuardrail` – lets LiteLLM look up metadata about the configured guardrail
+- `bedrock:ListGuardrails` – enables discovery of available guardrails when validating configuration
+
+If you still receive authorization errors, double-check that the guardrail and the credentials you are using live in the same 
+AWS account and region. The `aws_region_name` parameter must match the region where the guardrail was created; a mismatch will r
+esult in `ResourceNotFoundException` or similar Bedrock errors.
 
 ## PII Masking with Bedrock Guardrails
 


### PR DESCRIPTION
## Summary
- document the IAM permissions and region requirements needed to call Bedrock guardrails from LiteLLM
- cross-reference the Bedrock guardrail permissions guidance from the apply_guardrail endpoint doc

## Testing
- npm run lint *(fails: Missing script "lint" in docs/my-website/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d35810fe10832189eeacb6d3725ac3