### PR TITLE
Default Bedrock guardrail region to us-east-2

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -244,7 +244,7 @@ def resolve_bedrock_region_name(candidate_region: Optional[str]) -> str:
         if normalized_env_value is not None:
             return normalized_env_value
 
-    return "us-west-2"
+    return "us-east-2"
 
 
 class PiiEntityCategoryMap(TypedDict):


### PR DESCRIPTION
## Summary
- update `resolve_bedrock_region_name` so the fallback region defaults to `us-east-2`

## Testing
- pytest tests/proxy/guardrails/test_bedrock_guardrail.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c8a134a88321b72589634cc36284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default AWS Bedrock region to us-east-2 when no region is specified via configuration or environment. Previously, the fallback default was us-west-2. This affects automatic region selection only when a region isn’t provided. Existing setups that explicitly set a region are unaffected. If you rely on the default, ensure your permissions, endpoints, and quotas are available in us-east-2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->