### PR TITLE
Log Bedrock guardrail detections and surface them in UI

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -360,6 +360,7 @@ class CustomGuardrail(CustomLogger):
         end_time: Optional[float] = None,
         duration: Optional[float] = None,
         masked_entity_count: Optional[Dict[str, int]] = None,
+        guardrail_detected: Optional[bool] = None,
     ) -> None:
         """
         Builds `StandardLoggingGuardrailInformation` and adds it to the request metadata so it can be used for logging to DataDog, Langfuse, etc.
@@ -377,6 +378,7 @@ class CustomGuardrail(CustomLogger):
             ),
             guardrail_response=guardrail_json_response,
             guardrail_status=guardrail_status,
+            detected=guardrail_detected,
             start_time=start_time,
             end_time=end_time,
             duration=duration,

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -428,6 +428,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         guardrail_status: Literal["success", "failure"] = (
             "success" if response.status_code == 200 and payload_is_valid else "failure"
         )
+        guardrail_detected: Optional[bool] = None
+        if payload_is_valid and isinstance(guardrail_json_response, dict):
+            guardrail_detected = self._response_indicates_detection(
+                guardrail_json_response
+            )
+            if (
+                guardrail_detected is not None
+                and "detected" not in guardrail_json_response
+            ):
+                guardrail_json_response["detected"] = guardrail_detected
 
         #########################################################
         # Add guardrail information to request trace
@@ -439,6 +449,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             start_time=start_time.timestamp(),
             end_time=end_time.timestamp(),
             duration=(end_time - start_time).total_seconds(),
+            guardrail_detected=guardrail_detected,
         )
         #########################################################
         if response.status_code == 200:
@@ -455,6 +466,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 "Bedrock AI response : %s", guardrail_json_response
             )
             bedrock_guardrail_response = BedrockGuardrailResponse(**response_json)
+            if (
+                guardrail_detected is not None
+                and "detected" not in bedrock_guardrail_response
+            ):
+                bedrock_guardrail_response["detected"] = guardrail_detected
             if self._should_raise_guardrail_blocked_exception(
                 bedrock_guardrail_response
             ):
@@ -619,6 +635,91 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         # If we got here, intervention occurred but no BLOCKED actions found
         # This means all actions were ANONYMIZED or NONE, so don't raise exception
+        return False
+
+    def _response_indicates_detection(
+        self, response: Union[BedrockGuardrailResponse, dict]
+    ) -> Optional[bool]:
+        """
+        Determine whether the Bedrock response indicates a policy detection.
+
+        Returns:
+            True if a detection occurred, False if the payload explicitly shows
+            no detections, or None if we are unable to determine.
+        """
+
+        if not isinstance(response, dict):
+            return None
+
+        detected_flag = response.get("detected")
+        if isinstance(detected_flag, bool):
+            return detected_flag
+
+        action = response.get("action")
+        if isinstance(action, str) and action.upper() not in {
+            "",
+            "NONE",
+            "NO_ACTION",
+            "ALLOW",
+        }:
+            return True
+
+        if self._response_contains_detection(response):
+            return True
+
+        assessments = response.get("assessments")
+        if isinstance(assessments, list):
+            if any(self._response_contains_detection(assessment) for assessment in assessments):
+                return True
+            if len(assessments) > 0:
+                return False
+
+        return False
+
+    def _response_contains_detection(self, value: Any) -> bool:
+        """Recursively inspect the response for detection signals."""
+
+        if isinstance(value, dict):
+            detected_flag = value.get("detected")
+            if detected_flag is True:
+                return True
+
+            action_value = value.get("action")
+            if isinstance(action_value, str) and action_value.upper() not in {
+                "",
+                "NONE",
+                "NO_ACTION",
+                "ALLOW",
+            }:
+                return True
+
+            for key in (
+                "match",
+                "matches",
+                "annotations",
+                "topics",
+                "filters",
+                "customWords",
+                "managedWordLists",
+                "piiEntities",
+                "regexes",
+                "detections",
+            ):
+                if key in value and value[key]:
+                    return True
+
+            for nested in value.values():
+                if self._response_contains_detection(nested):
+                    return True
+
+            return False
+
+        if isinstance(value, list):
+            for item in value:
+                if self._response_contains_detection(item):
+                    return True
+            return False
+
         return False
 
     @log_guardrail_information

--- a/litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -121,3 +121,4 @@ class BedrockGuardrailResponse(TypedDict, total=False):
     output: Optional[List[BedrockGuardrailOutput]]
     outputs: Optional[List[BedrockGuardrailOutput]]
     assessments: Optional[List[BedrockGuardrailAssessment]]
+    detected: Optional[bool]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1977,6 +1977,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: Literal["success", "failure"]
+    detected: Optional[bool]
     start_time: Optional[float]
     end_time: Optional[float]
     duration: Optional[float]

--- a/tests/proxy/guardrails/test_bedrock_guardrail.py
+++ b/tests/proxy/guardrails/test_bedrock_guardrail.py
@@ -200,3 +200,41 @@ def test_make_bedrock_api_request_raises_on_json_decode_failure(patched_guardrai
     assert exc_info.value.detail["aws_response"] == mock_response.text
     logging_mock.assert_called_once()
     assert logging_mock.call_args.kwargs["guardrail_status"] == "failure"
+
+
+def test_make_bedrock_api_request_logs_detection(patched_guardrail):
+    guardrail = patched_guardrail
+    logging_mock = MagicMock()
+    guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
+
+    response_payload = {
+        "action": "NONE",
+        "assessments": [
+            {
+                "sensitiveInformationPolicy": {
+                    "piiEntities": [
+                        {"match": "john.doe@example.com", "action": "ANONYMIZED"}
+                    ]
+                }
+            }
+        ],
+    }
+
+    guardrail.async_handler.post = AsyncMock(
+        return_value=MockResponse(200, response_payload)
+    )
+
+    result = asyncio.run(
+        guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=[{"role": "user", "content": "hello"}],
+            request_data={"metadata": {}},
+        )
+    )
+
+    logging_mock.assert_called_once()
+    assert logging_mock.call_args.kwargs["guardrail_detected"] is True
+    logged_response = logging_mock.call_args.kwargs["guardrail_json_response"]
+    assert isinstance(logged_response, dict)
+    assert logged_response.get("detected") is True
+    assert result.get("detected") is True

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer.tsx
@@ -18,15 +18,23 @@ interface MaskedEntityCount {
   [key: string]: number;
 }
 
+type GuardrailResponse =
+  | GuardrailEntity[]
+  | Record<string, unknown>
+  | string
+  | null
+  | undefined
+
 interface GuardrailInformation {
-  duration: number;
-  end_time: number;
-  start_time: number;
-  guardrail_mode: string;
-  guardrail_name: string;
-  guardrail_status: string;
-  guardrail_response: GuardrailEntity[];
-  masked_entity_count: MaskedEntityCount;
+  duration?: number;
+  end_time?: number;
+  start_time?: number;
+  guardrail_mode?: string;
+  guardrail_name?: string;
+  guardrail_status?: string;
+  guardrail_response?: GuardrailResponse;
+  masked_entity_count?: MaskedEntityCount;
+  detected?: boolean;
 }
 
 interface GuardrailViewerProps {
@@ -38,17 +46,39 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
   const [entityListExpanded, setEntityListExpanded] = useState(true);
   const [expandedEntities, setExpandedEntities] = useState<Record<number, boolean>>({});
 
+  const guardrailResponse = data.guardrail_response;
+  const guardrailEntities = Array.isArray(guardrailResponse)
+    ? (guardrailResponse as GuardrailEntity[])
+    : null;
+  const hasStructuredResponse =
+    guardrailResponse !== null &&
+    typeof guardrailResponse === "object" &&
+    !Array.isArray(guardrailResponse);
+  const detectedStatus = typeof data.detected === "boolean"
+    ? data.detected
+    : guardrailEntities
+      ? guardrailEntities.length > 0
+      : undefined;
+
   if (!data) {
     return null;
   }
 
   // Calculate total masked entities
-  const totalMaskedEntities = data.masked_entity_count ? 
-    Object.values(data.masked_entity_count).reduce((sum, count) => sum + count, 0) : 0;
+  const totalMaskedEntities = data.masked_entity_count
+    ? Object.values(data.masked_entity_count).reduce((sum, count) => sum + count, 0)
+    : 0;
 
   const formatTime = (timestamp: number): string => {
     const date = new Date(timestamp * 1000);
     return date.toLocaleString();
+  };
+
+  const formatOptionalTime = (timestamp?: number): string => {
+    if (typeof timestamp !== "number") {
+      return "-";
+    }
+    return formatTime(timestamp);
   };
 
   const toggleEntity = (index: number) => {
@@ -79,13 +109,22 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
           <h3 className="text-lg font-medium">Guardrail Information</h3>
-          <span className={`ml-3 px-2 py-1 rounded-md text-xs font-medium inline-block ${
-            data.guardrail_status === "success" 
-              ? 'bg-green-100 text-green-800' 
-              : 'bg-red-100 text-red-800'
-          }`}>
-            {data.guardrail_status}
-          </span>
+          {data.guardrail_status && (
+            <span className={`ml-3 px-2 py-1 rounded-md text-xs font-medium inline-block ${
+              data.guardrail_status === "success"
+                ? 'bg-green-100 text-green-800'
+                : 'bg-red-100 text-red-800'
+            }`}>
+              {data.guardrail_status}
+            </span>
+          )}
+          {typeof detectedStatus === "boolean" && (
+            <span className={`ml-3 px-2 py-1 rounded-md text-xs font-medium inline-block ${
+              detectedStatus ? 'bg-orange-100 text-orange-800' : 'bg-gray-100 text-gray-600'
+            }`}>
+              {detectedStatus ? 'Detection flagged' : 'No detections'}
+            </span>
+          )}
           {totalMaskedEntities > 0 && (
             <span className="ml-3 px-2 py-1 bg-blue-50 text-blue-700 rounded-md text-xs font-medium">
               {totalMaskedEntities} masked {totalMaskedEntities === 1 ? 'entity' : 'entities'}
@@ -102,35 +141,39 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
               <div className="space-y-2">
                 <div className="flex">
                   <span className="font-medium w-1/3">Guardrail Name:</span>
-                  <span className="font-mono">{data.guardrail_name}</span>
+                  <span className="font-mono">{data.guardrail_name || '-'}</span>
                 </div>
                 <div className="flex">
                   <span className="font-medium w-1/3">Mode:</span>
-                  <span className="font-mono">{data.guardrail_mode}</span>
+                  <span className="font-mono">{data.guardrail_mode || '-'}</span>
                 </div>
                 <div className="flex">
                   <span className="font-medium w-1/3">Status:</span>
-                  <span className={`px-2 py-1 rounded-md text-xs font-medium inline-block ${
-                    data.guardrail_status === "success" 
-                      ? 'bg-green-100 text-green-800' 
-                      : 'bg-red-100 text-red-800'
-                  }`}>
-                    {data.guardrail_status}
-                  </span>
+                  {data.guardrail_status ? (
+                    <span className={`px-2 py-1 rounded-md text-xs font-medium inline-block ${
+                      data.guardrail_status === "success"
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-red-100 text-red-800'
+                    }`}>
+                      {data.guardrail_status}
+                    </span>
+                  ) : (
+                    <span>-</span>
+                  )}
                 </div>
               </div>
               <div className="space-y-2">
                 <div className="flex">
                   <span className="font-medium w-1/3">Start Time:</span>
-                  <span>{formatTime(data.start_time)}</span>
+                  <span>{formatOptionalTime(data.start_time)}</span>
                 </div>
                 <div className="flex">
                   <span className="font-medium w-1/3">End Time:</span>
-                  <span>{formatTime(data.end_time)}</span>
+                  <span>{formatOptionalTime(data.end_time)}</span>
                 </div>
                 <div className="flex">
                   <span className="font-medium w-1/3">Duration:</span>
-                  <span>{data.duration.toFixed(4)}s</span>
+                  <span>{typeof data.duration === "number" ? `${data.duration.toFixed(4)}s` : '-'}</span>
                 </div>
               </div>
             </div>
@@ -151,9 +194,9 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
           </div>
 
           {/* Detected Entities Section */}
-          {data.guardrail_response && data.guardrail_response.length > 0 && (
+          {guardrailEntities && guardrailEntities.length > 0 && (
             <div className="mt-4">
-              <div 
+              <div
                 className="flex items-center mb-2 cursor-pointer"
                 onClick={() => setEntityListExpanded(!entityListExpanded)}
               >
@@ -165,12 +208,12 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
-                <h4 className="font-medium">Detected Entities ({data.guardrail_response.length})</h4>
+                <h4 className="font-medium">Detected Entities ({guardrailEntities.length})</h4>
               </div>
-              
+
               {entityListExpanded && (
                 <div className="space-y-2">
-                  {data.guardrail_response.map((entity, index) => {
+                  {guardrailEntities.map((entity, index) => {
                     const isExpanded = expandedEntities[index] || false;
                     
                     return (
@@ -250,8 +293,26 @@ export function GuardrailViewer({ data }: GuardrailViewerProps) {
               )}
             </div>
           )}
+
+          {hasStructuredResponse && !guardrailEntities && (
+            <div className="mt-4">
+              <h4 className="font-medium mb-2">Guardrail Response</h4>
+              <pre className="bg-gray-900 text-gray-100 text-xs p-3 rounded-md overflow-auto">
+                {JSON.stringify(guardrailResponse, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {typeof guardrailResponse === "string" && guardrailResponse.trim().length > 0 && (
+            <div className="mt-4">
+              <h4 className="font-medium mb-2">Guardrail Response</h4>
+              <pre className="bg-gray-900 text-gray-100 text-xs p-3 rounded-md overflow-auto">
+                {guardrailResponse}
+              </pre>
+            </div>
+          )}
         </div>
       )}
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- extend standard guardrail logging to carry a `detected` flag and teach the Bedrock hook to compute it from ApplyGuardrail responses
- propagate the detection flag into the Bedrock guardrail response payload and surface it in the dashboard guardrail trace view
- add coverage that Bedrock detections are logged and keep UI rendering resilient when responses are not simple entity arrays

## Testing
- `pytest tests/proxy/guardrails/test_bedrock_guardrail.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3e1a053148321a131417b09c5a205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Surfaced guardrail detection status across logging and the dashboard, including a new detection badge.
  - Added display of guardrail responses (pretty-printed JSON or plain text) and richer Detected Entities details with toggles.
  - Enhanced time and duration display with sensible fallbacks when data is missing.

- Bug Fixes
  - Safer handling of optional fields in guardrail logs and UI to prevent rendering issues.

- Tests
  - Added unit test verifying detection is logged and propagated in Bedrock guardrail requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->