### PR TITLE
fix: remove unused router settings update

### DIFF
--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -288,15 +288,6 @@ const Settings: React.FC<SettingsPageProps> = ({
       setCallbacks(data.callbacks || []);
       setAllCallbacks(data.available_callbacks || []);
 
-      let router_settings = data.router_settings || {};
-      if (router_settings && typeof router_settings === "object") {
-        router_settings = { ...router_settings };
-        if ("model_group_retry_policy" in router_settings) {
-          delete router_settings["model_group_retry_policy"];
-        }
-      }
-      setRouterSettings(router_settings);
-
       const alerts_data = Array.isArray(data.alerts) ? data.alerts : [];
       setAlerts(alerts_data);
       if (alerts_data.length > 0) {


### PR DESCRIPTION
## Summary
- remove leftover router settings state update in settings component
- prevent reference to undefined setter to fix type error during build

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d46bf453388321bb3980a681d4ef04