### PR TITLE
Ensure bedrock guardrails persist across callback updates

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -262,10 +262,10 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                         config_file_path=config_file_path,
                     )
                 )
-        if isinstance(litellm.callbacks, list):
-            litellm.callbacks.extend(imported_list)
-        else:
-            litellm.callbacks = imported_list  # type: ignore
+        for callback_obj in imported_list:
+            litellm.logging_callback_manager.add_litellm_callback(  # type: ignore[arg-type]
+                callback_obj
+            )
 
         if "prometheus" in value:
             try:
@@ -276,12 +276,13 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
             if PrometheusLogger:
                 PrometheusLogger._mount_metrics_endpoint(premium_user)
     else:
-        litellm.callbacks = [
-            get_instance_fn(
-                value=value,
-                config_file_path=config_file_path,
-            )
-        ]
+        new_callback = get_instance_fn(
+            value=value,
+            config_file_path=config_file_path,
+        )
+        litellm.logging_callback_manager.add_litellm_callback(  # type: ignore[arg-type]
+            new_callback
+        )
     verbose_proxy_logger.debug(
         f"{blue_color_code} Initialized Callbacks - {litellm.callbacks} {reset_color_code}"
     )

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -193,15 +193,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
 
     def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
-        resolved_region_name = resolve_bedrock_region_name(
-            getattr(litellm_params, "aws_region_name", None)
-        )
         if litellm_params.guardrailIdentifier:
             self.guardrailIdentifier = litellm_params.guardrailIdentifier
         if litellm_params.guardrailVersion:
             self.guardrailVersion = litellm_params.guardrailVersion
-        if resolved_region_name:
-            self.optional_params["aws_region_name"] = resolved_region_name
+        region_from_params = getattr(litellm_params, "aws_region_name", None)
+        if region_from_params is not None:
+            resolved_region_name = resolve_bedrock_region_name(region_from_params)
+            if resolved_region_name:
+                self.optional_params["aws_region_name"] = resolved_region_name
         if litellm_params.disable_exception_on_block is not None:
             self.disable_exception_on_block = bool(
                 litellm_params.disable_exception_on_block

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -35,6 +35,7 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import (
     BedrockGuardrailConfigModel,
     GuardrailEventHooks,
+    LitellmParams,
     resolve_bedrock_region_name,
 )
 from litellm.types.llms.openai import AllMessageValues
@@ -189,7 +190,44 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             self.guardrailIdentifier,
             self.guardrailVersion,
         )
-    
+
+
+    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+        resolved_region_name = resolve_bedrock_region_name(
+            getattr(litellm_params, "aws_region_name", None)
+        )
+        if litellm_params.guardrailIdentifier:
+            self.guardrailIdentifier = litellm_params.guardrailIdentifier
+        if litellm_params.guardrailVersion:
+            self.guardrailVersion = litellm_params.guardrailVersion
+        if resolved_region_name:
+            self.optional_params["aws_region_name"] = resolved_region_name
+        if litellm_params.disable_exception_on_block is not None:
+            self.disable_exception_on_block = bool(
+                litellm_params.disable_exception_on_block
+            )
+
+        optional_param_keys = [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_session_name",
+            "aws_profile_name",
+            "aws_role_name",
+            "aws_web_identity_token",
+            "aws_sts_endpoint",
+            "aws_bedrock_runtime_endpoint",
+            "mask_request_content",
+            "mask_response_content",
+        ]
+
+        for key in optional_param_keys:
+            value = getattr(litellm_params, key, None)
+            if value is not None:
+                self.optional_params[key] = value
+            else:
+                self.optional_params.pop(key, None)
+
 
     def _create_bedrock_input_content_request(self, messages: Optional[List[AllMessageValues]]) -> BedrockRequest:
         """

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -4,7 +4,7 @@ import importlib
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Type, cast
+from typing import Any, Dict, List, Optional, Type, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -16,6 +16,7 @@ from litellm.types.guardrails import (
     Guardrail,
     GuardrailEventHooks,
     LakeraCategoryThresholds,
+    BaseLitellmParams,
     LitellmParams,
     SupportedGuardrailIntegrations,
 )
@@ -382,29 +383,41 @@ class InMemoryGuardrailHandler:
         """
         guardrail_id = guardrail.get("guardrail_id") or str(uuid.uuid4())
         guardrail["guardrail_id"] = guardrail_id
+
+        raw_litellm_params: Any = guardrail.get("litellm_params", {})
+        verbose_proxy_logger.debug("litellm_params= %s", raw_litellm_params)
+        litellm_params = self._coerce_to_litellm_params(raw_litellm_params)
+
+        if isinstance(raw_litellm_params, dict) and raw_litellm_params.get(
+            "category_thresholds"
+        ):
+            lakera_category_thresholds = LakeraCategoryThresholds(
+                **raw_litellm_params["category_thresholds"]
+            )
+            litellm_params.category_thresholds = lakera_category_thresholds
+
         if guardrail_id in self.IN_MEMORY_GUARDRAILS:
             verbose_proxy_logger.debug(
                 "guardrail_id already exists in IN_MEMORY_GUARDRAILS"
             )
-            return self.IN_MEMORY_GUARDRAILS[guardrail_id]
+            existing_guardrail = self.IN_MEMORY_GUARDRAILS[guardrail_id]
+            existing_guardrail["guardrail_name"] = guardrail.get("guardrail_name", "")
+            existing_guardrail["litellm_params"] = litellm_params
+
+            custom_guardrail_callback = self.guardrail_id_to_custom_guardrail.get(
+                guardrail_id
+            )
+            if (
+                custom_guardrail_callback is not None
+                and isinstance(litellm_params, LitellmParams)
+            ):
+                custom_guardrail_callback.update_in_memory_litellm_params(
+                    litellm_params=litellm_params
+                )
+            self._ensure_callback_registered(custom_guardrail_callback)
+            return existing_guardrail
 
         custom_guardrail_callback: Optional[CustomGuardrail] = None
-        litellm_params_data = guardrail["litellm_params"]
-        verbose_proxy_logger.debug("litellm_params= %s", litellm_params_data)
-
-        if isinstance(litellm_params_data, dict):
-            litellm_params = LitellmParams(**litellm_params_data)
-        else:
-            litellm_params = litellm_params_data
-
-        if (
-            "category_thresholds" in litellm_params_data
-            and litellm_params_data["category_thresholds"]
-        ):
-            lakera_category_thresholds = LakeraCategoryThresholds(
-                **litellm_params_data["category_thresholds"]
-            )
-            litellm_params.category_thresholds = lakera_category_thresholds
 
         if litellm_params.api_key and litellm_params.api_key.startswith("os.environ/"):
             litellm_params.api_key = str(get_secret(litellm_params.api_key))
@@ -508,18 +521,20 @@ class InMemoryGuardrailHandler:
         - updates the guardrail in memory
         - updates the guardrail params in litellm.callback_manager
         """
+        litellm_params = self._coerce_to_litellm_params(
+            guardrail.get("litellm_params", {})
+        )
+        guardrail["litellm_params"] = litellm_params
         self.IN_MEMORY_GUARDRAILS[guardrail_id] = guardrail
 
         custom_guardrail_callback = self.guardrail_id_to_custom_guardrail.get(
             guardrail_id
         )
         if custom_guardrail_callback:
-            updated_litellm_params = cast(
-                LitellmParams, guardrail.get("litellm_params", {})
-            )
             custom_guardrail_callback.update_in_memory_litellm_params(
-                litellm_params=updated_litellm_params
+                litellm_params=litellm_params
             )
+        self._ensure_callback_registered(custom_guardrail_callback)
 
     def delete_in_memory_guardrail(self, guardrail_id: str) -> None:
         """
@@ -538,6 +553,30 @@ class InMemoryGuardrailHandler:
         Get a guardrail by its ID from memory
         """
         return self.IN_MEMORY_GUARDRAILS.get(guardrail_id)
+
+    def _coerce_to_litellm_params(
+        self, litellm_params_data: Any
+    ) -> LitellmParams:
+        if isinstance(litellm_params_data, LitellmParams):
+            return litellm_params_data
+        if isinstance(litellm_params_data, BaseLitellmParams):
+            return LitellmParams(**litellm_params_data.model_dump())
+        if isinstance(litellm_params_data, dict):
+            return LitellmParams(**litellm_params_data)
+        raise ValueError("litellm_params must be a dict or LitellmParams instance")
+
+    def _ensure_callback_registered(
+        self, custom_guardrail_callback: Optional[CustomGuardrail]
+    ) -> None:
+        if custom_guardrail_callback is None:
+            return
+        active_guardrails = litellm.logging_callback_manager.get_custom_loggers_for_type(
+            callback_type=CustomGuardrail
+        )
+        if custom_guardrail_callback not in active_guardrails:
+            litellm.logging_callback_manager.add_litellm_callback(
+                custom_guardrail_callback
+            )
 
 
 ########################################################


### PR DESCRIPTION
## Summary
- keep existing callbacks when updating logging so guardrail hooks are not dropped
- ensure in-memory guardrail registry refreshes stored params and re-registers callbacks for existing guardrails
- allow the bedrock guardrail implementation to refresh its AWS configuration when params change

## Testing
- pytest tests/proxy/guardrails/test_bedrock_guardrail.py

------
https://chatgpt.com/codex/tasks/task_e_68d47fde0a70832196e2356193021381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Update guardrail settings in-memory (region, version, optional AWS params) without restart.
  - Accept multiple parameter formats (objects or dicts) for guardrail configuration.
  - Automatic registration and upkeep of custom guardrail callbacks.
  - Direct support for category thresholds in guardrail setup.

- Bug Fixes
  - More reliable reuse and update of existing in-memory guardrails.
  - Improved handling of API keys and secrets from environment variables.

- Refactor
  - Streamlined callback registration for greater stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->