### PR TITLE
Fix duplicate guardrail callback registrations

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -5,7 +5,6 @@ from litellm import get_secret
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import CommonProxyErrors, LiteLLMPromptInjectionParams
 from litellm.proxy.types_utils.utils import get_instance_fn
-from litellm.integrations.custom_logger import CustomLogger
 
 blue_color_code = "\033[94m"
 reset_color_code = "\033[0m"
@@ -22,35 +21,34 @@ def _remove_existing_callback_registration(callback_obj: Any) -> None:
         getattr(litellm, "_async_failure_callback", None),
     ]
 
-    candidate_names: set[str] = set()
+    candidate_names: set[str]
 
     def _collect_names(obj: Any) -> set[str]:
         names: set[str] = set()
+        if isinstance(obj, str):
+            names.add(obj)
+            return names
         for attr in ("guardrail_name", "callback_name"):
             value = getattr(obj, attr, None)
             if isinstance(value, str):
                 names.add(value)
         return names
 
-    if isinstance(callback_obj, CustomLogger):
-        candidate_names = _collect_names(callback_obj)
-
-        def _matches(existing: Any) -> bool:
-            if not isinstance(existing, CustomLogger):
-                return False
-            existing_names = _collect_names(existing)
-            if candidate_names and existing_names.intersection(candidate_names):
-                return True
-            return type(existing) is type(callback_obj)
-
-    elif isinstance(callback_obj, str):
+    if isinstance(callback_obj, str):
         candidate_names = {callback_obj}
 
         def _matches(existing: Any) -> bool:
             return isinstance(existing, str) and existing == callback_obj
 
     else:
-        return
+        candidate_names = _collect_names(callback_obj)
+        candidate_type = type(callback_obj)
+
+        def _matches(existing: Any) -> bool:
+            existing_names = _collect_names(existing)
+            if candidate_names and existing_names.intersection(candidate_names):
+                return True
+            return type(existing) is candidate_type
 
     for callback_list in callback_lists:
         if not isinstance(callback_list, list):


### PR DESCRIPTION
## Summary
- add callback replacement helper to prevent duplicate registrations when guardrail callbacks are re-initialized
- reuse the helper before registering new callbacks so refreshed configs update existing entries instead of appending duplicates

## Testing
- python -m compileall litellm/proxy/common_utils/callback_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d48acd89c083218d99e70a01d27b64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate callback registrations by removing/replacing existing entries when callbacks are re-imported or updated, reducing repeated logs/metrics and unintended side effects.

- Improvements
  - Automatically cleans up prior callback registrations before adding new ones for more reliable behavior.
  - Adds clearer debug logging when a callback is replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->