### PR TITLE
Update Bedrock guardrail masking toggles

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -221,8 +221,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             "mask_response_content",
         ]
 
+        mask_keys = ("mask_request_content", "mask_response_content")
+
         for key in optional_param_keys:
             value = getattr(litellm_params, key, None)
+            if key in mask_keys:
+                if value is not None:
+                    bool_value = bool(value)
+                    setattr(self, key, bool_value)
+                    self.optional_params[key] = bool_value
+                else:
+                    self.optional_params.pop(key, None)
+                continue
+
             if value is not None:
                 self.optional_params[key] = value
             else:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -223,15 +223,18 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         mask_keys = ("mask_request_content", "mask_response_content")
 
+        def _sync_mask_toggle(key: str, value: Optional[Any]) -> None:
+            if value is None:
+                self.optional_params.pop(key, None)
+                return
+            bool_value = bool(value)
+            setattr(self, key, bool_value)
+            self.optional_params[key] = bool_value
+
         for key in optional_param_keys:
             value = getattr(litellm_params, key, None)
             if key in mask_keys:
-                if value is not None:
-                    bool_value = bool(value)
-                    setattr(self, key, bool_value)
-                    self.optional_params[key] = bool_value
-                else:
-                    self.optional_params.pop(key, None)
+                _sync_mask_toggle(key, value)
                 continue
 
             if value is not None:


### PR DESCRIPTION
## Summary
- update Bedrock guardrail parameter refresh to sync mask_request_content and mask_response_content attributes with incoming params
- normalize stored optional params for mask toggles to booleans while preserving existing pop behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d490607e188321ba4411ffeb684569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional settings to mask request content and response content.
  * These settings accept boolean values and are applied consistently when provided.
  * If left unset, they are ignored and do not affect other options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->