### PR TITLE
Expose Bedrock guardrail assessments in response metadata

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -387,11 +387,17 @@ class CustomGuardrail(CustomLogger):
         if "metadata" in request_data:
             if request_data["metadata"] is None:
                 request_data["metadata"] = {}
-            request_data["metadata"]["standard_logging_guardrail_information"] = slg
+            request_data["metadata"][
+                "standard_logging_guardrail_information"
+            ] = slg
+            request_data["metadata"]["guardrail_information"] = slg
         elif "litellm_metadata" in request_data:
+            if request_data["litellm_metadata"] is None:
+                request_data["litellm_metadata"] = {}
             request_data["litellm_metadata"][
                 "standard_logging_guardrail_information"
             ] = slg
+            request_data["litellm_metadata"]["guardrail_information"] = slg
         else:
             verbose_logger.warning(
                 "unable to log guardrail information. No metadata found in request_data"

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3888,6 +3888,7 @@ class StandardLoggingPayloadSetup:
             requester_custom_headers=None,
             user_api_key_request_route=None,
             cold_storage_object_key=None,
+            guardrail_information=None,
         )
         if isinstance(metadata, dict):
             # Filter the metadata dictionary to include only the specified keys
@@ -4548,6 +4549,7 @@ def get_standard_logging_metadata(
         requester_custom_headers=None,
         user_api_key_request_route=None,
         cold_storage_object_key=None,
+        guardrail_information=None,
     )
     if isinstance(metadata, dict):
         # Filter the metadata dictionary to include only the specified keys

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1911,6 +1911,7 @@ class StandardLoggingMetadata(StandardLoggingUserAPIKeyMetadata):
     applied_guardrails: Optional[List[str]]
     usage_object: Optional[dict]
     cold_storage_object_key: Optional[str]  # S3/GCS object key for cold storage retrieval
+    guardrail_information: Optional["StandardLoggingGuardrailInformation"]
 
 
 class StandardLoggingAdditionalHeaders(TypedDict, total=False):

--- a/tests/proxy/guardrails/test_bedrock_guardrail.py
+++ b/tests/proxy/guardrails/test_bedrock_guardrail.py
@@ -127,7 +127,10 @@ def test_bedrock_guardrail_metadata_disabled_does_not_raise(monkeypatch):
 
 def test_make_bedrock_api_request_raises_forbidden(patched_guardrail):
     guardrail = patched_guardrail
-    logging_mock = MagicMock()
+    original_logging_method = (
+        guardrail.add_standard_logging_guardrail_information_to_request_data
+    )
+    logging_mock = MagicMock(side_effect=original_logging_method)
     guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
 
     response_payload = {"message": "Access denied"}
@@ -150,7 +153,10 @@ def test_make_bedrock_api_request_raises_forbidden(patched_guardrail):
 
 def test_make_bedrock_api_request_raises_server_error(patched_guardrail):
     guardrail = patched_guardrail
-    logging_mock = MagicMock()
+    original_logging_method = (
+        guardrail.add_standard_logging_guardrail_information_to_request_data
+    )
+    logging_mock = MagicMock(side_effect=original_logging_method)
     guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
 
     response_payload = {"message": "Internal error"}
@@ -174,7 +180,10 @@ def test_make_bedrock_api_request_raises_server_error(patched_guardrail):
 
 def test_make_bedrock_api_request_raises_on_json_decode_failure(patched_guardrail):
     guardrail = patched_guardrail
-    logging_mock = MagicMock()
+    original_logging_method = (
+        guardrail.add_standard_logging_guardrail_information_to_request_data
+    )
+    logging_mock = MagicMock(side_effect=original_logging_method)
     guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
 
     json_error = json.JSONDecodeError("Expecting value", "", 0)
@@ -204,7 +213,10 @@ def test_make_bedrock_api_request_raises_on_json_decode_failure(patched_guardrai
 
 def test_make_bedrock_api_request_logs_detection(patched_guardrail):
     guardrail = patched_guardrail
-    logging_mock = MagicMock()
+    original_logging_method = (
+        guardrail.add_standard_logging_guardrail_information_to_request_data
+    )
+    logging_mock = MagicMock(side_effect=original_logging_method)
     guardrail.add_standard_logging_guardrail_information_to_request_data = logging_mock
 
     response_payload = {
@@ -224,11 +236,12 @@ def test_make_bedrock_api_request_logs_detection(patched_guardrail):
         return_value=MockResponse(200, response_payload)
     )
 
+    request_payload = {"metadata": {}}
     result = asyncio.run(
         guardrail.make_bedrock_api_request(
             source="INPUT",
             messages=[{"role": "user", "content": "hello"}],
-            request_data={"metadata": {}},
+            request_data=request_payload,
         )
     )
 
@@ -238,3 +251,7 @@ def test_make_bedrock_api_request_logs_detection(patched_guardrail):
     assert isinstance(logged_response, dict)
     assert logged_response.get("detected") is True
     assert result.get("detected") is True
+    guardrail_information = request_payload["metadata"]["guardrail_information"]
+    assert guardrail_information["guardrail_response"]["assessments"][0][
+        "sensitiveInformationPolicy"
+    ]["piiEntities"][0]["match"] == "[REDACTED]"


### PR DESCRIPTION
## Summary
- duplicate guardrail logging information onto the `guardrail_information` metadata key so sanitized Bedrock assessments persist into response logs
- teach the standard logging metadata schema about guardrail details and ensure they are initialized in logging helpers
- extend the Bedrock guardrail test to assert that redacted assessment data is written into the metadata

## Testing
- pytest tests/proxy/guardrails/test_bedrock_guardrail.py


------
https://chatgpt.com/codex/tasks/task_e_68d512ae7be8832192be9c834ccebc7b