### PR TITLE
Fix RequestViewer props for session view

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
@@ -15,9 +15,17 @@ interface SessionViewProps {
   sessionId: string
   logs: LogEntry[]
   onBack: () => void
+  accessToken: string
+  formattedStartTime: string
 }
 
-export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBack }) => {
+export const SessionView: React.FC<SessionViewProps> = ({
+  sessionId,
+  logs,
+  onBack,
+  accessToken,
+  formattedStartTime,
+}) => {
   // Track which log row is expanded
   const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null)
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
@@ -178,7 +186,13 @@ export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBac
         <DataTable
           columns={columns}
           data={logs}
-          renderSubComponent={RequestViewer}
+          renderSubComponent={({ row }) => (
+            <RequestViewer
+              row={row}
+              accessToken={accessToken}
+              formattedStartTime={formattedStartTime}
+            />
+          )}
           getRowCanExpand={() => true}
           loadingMessage="Loading logs..."
           noDataMessage="No logs found"

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -452,6 +452,8 @@ export default function SpendLogsTable({
           sessionId={selectedSessionId}
           logs={sessionLogs.data.data}
           onBack={() => setSelectedSessionId(null)}
+          accessToken={accessToken as string}
+          formattedStartTime={formattedStartTime}
         />
       </div>
     )


### PR DESCRIPTION
## Summary
- add the access token and formatted start time props to the session view so the sub-row renderer has the data it requires
- update the spend logs table to provide the new props when rendering a session's log table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5189f4b688321b013b485f6c5e6b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Session details now display a clearly formatted session start time for easier reading.
  - Request details within a session load using your current authentication, enabling access to protected data when viewing logs.
  - Seamless handoff of session context to the request viewer improves continuity when navigating from logs to detailed request views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->