### PR TITLE
Fix RequestViewer props for session view

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
@@ -15,9 +15,17 @@ interface SessionViewProps {
   sessionId: string
   logs: LogEntry[]
   onBack: () => void
+  accessToken: string
+  formattedStartTime: string
 }
 
-export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBack }) => {
+export const SessionView: React.FC<SessionViewProps> = ({
+  sessionId,
+  logs,
+  onBack,
+  accessToken,
+  formattedStartTime,
+}) => {
   // Track which log row is expanded
   const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null)
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
@@ -178,7 +186,13 @@ export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBac
         <DataTable
           columns={columns}
           data={logs}
-          renderSubComponent={RequestViewer}
+          renderSubComponent={({ row }) => (
+            <RequestViewer
+              row={row}
+              accessToken={accessToken}
+              formattedStartTime={formattedStartTime}
+            />
+          )}
           getRowCanExpand={() => true}
           loadingMessage="Loading logs..."
           noDataMessage="No logs found"

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -452,6 +452,8 @@ export default function SpendLogsTable({
           sessionId={selectedSessionId}
           logs={sessionLogs.data.data}
           onBack={() => setSelectedSessionId(null)}
+          accessToken={accessToken as string}
+          formattedStartTime={formattedStartTime}
         />
       </div>
     )
@@ -791,7 +793,7 @@ export function RequestViewer({ row, accessToken, formattedStartTime }: RequestV
   })
 
   const logData = useMemo<LogEntry>(() => {
-    const overrides = prefetchedDetails ?? {}
+    const overrides: Partial<PrefetchedLog> = prefetchedDetails ?? {}
 
     return {
       ...row.original,


### PR DESCRIPTION
## Summary
- add the access token and formatted start time props to the session view so the sub-row renderer has the data it requires
- update the spend logs table to provide the new props when rendering a session's log table
- ensure the prefetched log overrides are typed as partial data so optional fields remain accessible without type errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5189f4b688321b013b485f6c5e6b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Session logs now display a consistent, formatted session start time across views.
  - Request details in the log viewer are fetched using your current authorization, improving access to protected data and reliability.

- Refactor
  - Improved type handling for prefetched log overrides to increase stability and reduce edge-case errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->