### PR TITLE
Ensure deepMerge preserves guardrail params typing

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/edit_guardrail_form.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/edit_guardrail_form.tsx
@@ -60,7 +60,9 @@ interface ProviderParamsResponse {
   [provider: string]: { [key: string]: ProviderParam };
 }
 
-type ProviderParamStructure = Record<string, ProviderParamStructure | true>;
+interface ProviderParamStructure {
+  [key: string]: ProviderParamStructure | true;
+}
 
 const collectAllowedParamKeys = (
   fields: { [key: string]: ProviderParam } | undefined
@@ -218,7 +220,7 @@ const extractStructuredProviderValues = (
   return traverse(structure, []);
 };
 
-const deepMerge = (target: Record<string, any>, source: Record<string, any>) => {
+const deepMerge = <T extends Record<string, any>>(target: T, source: Record<string, any>): T => {
   const output: Record<string, any> = { ...target };
 
   Object.entries(source).forEach(([key, sourceValue]) => {
@@ -237,7 +239,7 @@ const deepMerge = (target: Record<string, any>, source: Record<string, any>) => 
     }
   });
 
-  return output;
+  return output as T;
 };
 
 const EditGuardrailForm: React.FC<EditGuardrailFormProps> = ({


### PR DESCRIPTION
## Summary
- make deepMerge generic so it returns the original litellm_params shape
- resolve the TypeScript assignment error triggered when merging structured provider values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f07a7eec14832f85e5a0232efc3bd9